### PR TITLE
docs: add root setup flow and Supabase env reference table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Supabase local (copie de `npm run supabase:status`)
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# Mobile (opcional)
+EXPO_PUBLIC_SUPABASE_URL=http://10.0.2.2:54321
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+EXPO_PUBLIC_APP_ENV=development

--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ Equipe administrativa hospitalar responsável por cadastrar pacientes, manter pr
 - ESLint
 - Prettier
 
+## Setup local rápido
+
+1. `cp .env.example .env`
+2. `npm run setup`
+3. `npm run supabase:start`
+4. `npm run dev`
+
+### Variáveis Supabase (referência do `supabase status`)
+
+| Nome no `supabase status` | Nome no `.env` raiz | Serviço consumidor | Obrigatório? |
+| --- | --- | --- | --- |
+| API URL | `SUPABASE_URL` | backend e mobile | obrigatório |
+| anon key | `SUPABASE_ANON_KEY` | backend e mobile | obrigatório |
+| service_role key | `SUPABASE_SERVICE_ROLE_KEY` | backend | obrigatório |
+| JWT secret | `SUPABASE_JWT_SECRET` | backend | obrigatório |
+| DB URL | `DATABASE_URL` | backend | obrigatório |
+| _(não vem do Supabase status)_ | `EXPO_PUBLIC_APP_ENV` | mobile | opcional |
+
+> Observação: no mobile, use os equivalentes `EXPO_PUBLIC_SUPABASE_URL` e `EXPO_PUBLIC_SUPABASE_ANON_KEY` no `.env` de `mobile/` para apontar para o host correto (emulador/dispositivo físico).
+
 ## Arquitetura
 
 ```text


### PR DESCRIPTION
### Motivation

- Provide a simple, copy-and-run local setup flow to get backend, mobile and Supabase running quickly. 
- Make Supabase-required environment variables explicit and map the `supabase status` names to the project's `.env` names and consumers.

### Description

- Add a `Setup local rápido` section to the root `README.md` with the quick commands `cp .env.example .env`, `npm run setup`, `npm run supabase:start` and `npm run dev`.
- Include a table in `README.md` mapping `supabase status` names to root `.env` variables, indicating the consuming service and whether each variable is required.
- Add a note pointing developers to use `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` in `mobile/` when running on emulators or physical devices.
- Create a consolidated root `.env.example` containing `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`, `DATABASE_URL` and optional mobile keys `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_ANON_KEY`, `EXPO_PUBLIC_APP_ENV`.

### Testing

- Ran `git diff --check` which completed without warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb981491848329b7130cf3ebcf166b)