### PR TITLE
docs: adicionar mapeamento de variáveis Supabase no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,15 @@ O projeto será organizado com:
 4. iniciar o app mobile
 5. autenticar e validar o fluxo ponta a ponta
 
+### Mapeamento de variáveis do Supabase
+
+Para evitar ambiguidade entre os nomes exibidos pela Supabase CLI e os nomes usados no projeto, utilize o mapeamento abaixo:
+
+| Origem (Supabase CLI) | Variável no projeto | Onde usar |
+| --- | --- | --- |
+| `anon key` / `ANON_KEY` | `SUPABASE_ANON_KEY` | backend |
+| `anon key` / `ANON_KEY` | `EXPO_PUBLIC_SUPABASE_ANON_KEY` | mobile (Expo) |
+
 > Observação: durante o desenvolvimento mobile, a API deve ser consumida pelo IP da máquina hospedeira, e não por `localhost`, quando o app estiver rodando em dispositivo físico.
 
 ### Scripts iniciais (raiz)


### PR DESCRIPTION
### Motivation
- Remover ambiguidade entre os nomes exibidos pela Supabase CLI e as variáveis de ambiente usadas pelo projeto para facilitar a configuração local do backend e do app mobile.

### Description
- Adiciona seção `Mapeamento de variáveis do Supabase` no `README.md` com tabela que mapeia `anon key` / `ANON_KEY` para `SUPABASE_ANON_KEY` (backend) e `EXPO_PUBLIC_SUPABASE_ANON_KEY` (mobile/Expo).

### Testing
- Nenhum teste automatizado foi executado porque a alteração é apenas de documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9813ccb8832980688b1fbb77ef8d)