### PR TITLE
docs: alinhar README e docs com Expo Router, prefixo /api e portas locais

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ PostgreSQL + Auth (Supabase local)
 ## Estrutura do repositório
 
 ```text
-hospagenda/
+projeto-pdhc/
   backend/
   mobile/
   docs/
@@ -166,12 +166,15 @@ backend/
 
 ```text
 mobile/
+  app/
+    _layout.tsx
+    index.tsx
+    auth/
+    (protected)/
   src/
-    screens/
     components/
     services/
     hooks/
-    navigation/
     types/
     utils/
     constants/
@@ -180,35 +183,45 @@ mobile/
 ## Endpoints do MVP
 
 ### Auth
-- `GET /auth/me`
+- `GET /api/auth/me`
 
 ### Specialties
-- `POST /specialties`
-- `GET /specialties`
+- `POST /api/specialties`
+- `GET /api/specialties`
 
 ### Professionals
-- `POST /professionals`
-- `GET /professionals`
-- `GET /professionals/:id`
-- `PATCH /professionals/:id`
+- `POST /api/professionals`
+- `GET /api/professionals`
+- `GET /api/professionals/:id`
+- `PATCH /api/professionals/:id`
 
 ### Patients
-- `POST /patients`
-- `GET /patients`
-- `GET /patients/:id`
-- `PATCH /patients/:id`
+- `POST /api/patients`
+- `GET /api/patients`
+- `GET /api/patients/:id`
+- `PATCH /api/patients/:id`
 
 ### Appointments
-- `POST /appointments`
-- `GET /appointments`
-- `GET /appointments/:id`
-- `PATCH /appointments/:id/confirm`
-- `PATCH /appointments/:id/reschedule`
-- `PATCH /appointments/:id/cancel`
-- `PATCH /appointments/:id/complete`
+- `POST /api/appointments`
+- `GET /api/appointments`
+- `GET /api/appointments/:id`
+- `PATCH /api/appointments/:id/confirm`
+- `PATCH /api/appointments/:id/reschedule`
+- `PATCH /api/appointments/:id/cancel`
+- `PATCH /api/appointments/:id/complete`
 
 ### Dashboard
-- `GET /dashboard/today`
+- `GET /api/dashboard/today`
+
+## Portas e URLs locais
+
+- backend NestJS: `http://127.0.0.1:3000` com prefixo global `api`
+- Supabase API local: `http://127.0.0.1:54321`
+- Postgres local (Supabase): `127.0.0.1:54322`
+
+## Nota de sincronização documental
+
+Sempre que houver mudança de rota, script ou variável de ambiente, atualize `README.md` e os arquivos em `docs/` no mesmo ciclo de alteração para manter contrato, arquitetura e setup alinhados.
 
 ## Fluxos principais
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -2,7 +2,22 @@
 
 ## Convenções gerais
 ### Base URL
-A URL base será definida por ambiente. Em desenvolvimento local, a aplicação mobile consumirá a API NestJS utilizando o IP da máquina na rede local, e não `localhost` diretamente no dispositivo físico.
+A URL base será definida por ambiente. Em desenvolvimento local:
+
+- backend NestJS: `http://127.0.0.1:3000`
+- prefixo global obrigatório das rotas da API: `/api`
+- Supabase API local: `http://127.0.0.1:54321`
+- Postgres local (Supabase): `127.0.0.1:54322`
+
+Em dispositivo físico, o mobile deve usar o IP da máquina na LAN, preservando porta e prefixo (ex.: `http://192.168.0.10:3000/api`).
+
+### Prefixo de rotas
+Todas as rotas deste contrato são servidas sob o prefixo `/api`.
+
+Exemplos:
+- `/api/auth/me`
+- `/api/patients`
+- `/api/appointments/:id/confirm`
 
 ### Autenticação
 As rotas protegidas exigem bearer token no header:
@@ -17,7 +32,7 @@ O token será emitido pelo Supabase Auth e validado pela API NestJS.
 O projeto pode adotar resposta direta por recurso ou um padrão padronizado. Para o MVP, a prioridade é manter consistência simples e clareza.
 
 ## Auth
-### GET `/auth/me`
+### GET `/api/auth/me`
 Retorna os dados básicos do usuário autenticado.
 
 #### Resposta esperada
@@ -29,7 +44,7 @@ Retorna os dados básicos do usuário autenticado.
 ```
 
 ## Specialties
-### POST `/specialties`
+### POST `/api/specialties`
 Cria uma nova especialidade.
 
 #### Request body
@@ -43,7 +58,7 @@ Cria uma nova especialidade.
 - nome é obrigatório
 - nome deve ser válido e não vazio
 
-### GET `/specialties`
+### GET `/api/specialties`
 Lista especialidades cadastradas.
 
 #### Resposta esperada
@@ -58,7 +73,7 @@ Lista especialidades cadastradas.
 ```
 
 ## Professionals
-### POST `/professionals`
+### POST `/api/professionals`
 Cria um profissional.
 
 #### Request body
@@ -74,13 +89,13 @@ Cria um profissional.
 - `specialtyId` deve existir
 - um profissional possui apenas uma especialidade
 
-### GET `/professionals`
+### GET `/api/professionals`
 Lista profissionais.
 
-### GET `/professionals/:id`
+### GET `/api/professionals/:id`
 Retorna detalhes de um profissional.
 
-### PATCH `/professionals/:id`
+### PATCH `/api/professionals/:id`
 Edita dados do profissional.
 
 #### Request body
@@ -91,7 +106,7 @@ Edita dados do profissional.
 ```
 
 ## Patients
-### POST `/patients`
+### POST `/api/patients`
 Cria um paciente.
 
 #### Request body
@@ -110,17 +125,17 @@ Cria um paciente.
 - data de nascimento é obrigatória
 - telefone é obrigatório no MVP apenas se isso fizer sentido no fluxo
 
-### GET `/patients`
+### GET `/api/patients`
 Lista pacientes.
 
-### GET `/patients/:id`
+### GET `/api/patients/:id`
 Retorna detalhes de um paciente.
 
-### PATCH `/patients/:id`
+### PATCH `/api/patients/:id`
 Edita dados do paciente.
 
 ## Appointments
-### POST `/appointments`
+### POST `/api/appointments`
 Cria um agendamento.
 
 #### Request body
@@ -155,7 +170,7 @@ Cria um agendamento.
 }
 ```
 
-### GET `/appointments`
+### GET `/api/appointments`
 Lista agendamentos.
 
 #### Filtros suportados
@@ -166,20 +181,20 @@ Lista agendamentos.
 
 #### Exemplo
 ```http
-GET /appointments?date=2026-04-20&status=SCHEDULED&professionalId=professional-id
+GET /api/appointments?date=2026-04-20&status=SCHEDULED&professionalId=professional-id
 ```
 
-### GET `/appointments/:id`
+### GET `/api/appointments/:id`
 Retorna detalhes de um agendamento.
 
-### PATCH `/appointments/:id/confirm`
+### PATCH `/api/appointments/:id/confirm`
 Confirma um agendamento.
 
 #### Regras
 - só pode confirmar consulta ativa
 - não faz sentido confirmar consulta cancelada ou concluída
 
-### PATCH `/appointments/:id/reschedule`
+### PATCH `/api/appointments/:id/reschedule`
 Remarca um agendamento.
 
 #### Request body
@@ -193,21 +208,21 @@ Remarca um agendamento.
 - deve validar novamente data futura
 - deve validar novamente conflito de horário
 
-### PATCH `/appointments/:id/cancel`
+### PATCH `/api/appointments/:id/cancel`
 Cancela um agendamento.
 
 #### Regras
 - não remove o registro fisicamente
 - apenas altera o status para `CANCELLED`
 
-### PATCH `/appointments/:id/complete`
+### PATCH `/api/appointments/:id/complete`
 Conclui um agendamento.
 
 #### Regras
 - só pode concluir consulta não cancelada
 
 ## Dashboard
-### GET `/dashboard/today`
+### GET `/api/dashboard/today`
 Retorna resumo dos atendimentos do dia.
 
 #### Exemplo de resposta
@@ -252,3 +267,6 @@ Os erros devem seguir um padrão consistente e legível para o mobile.
 - a documentação definitiva dos endpoints será refletida no Swagger/OpenAPI
 - este arquivo serve como contrato inicial entre backend e mobile
 - alterações relevantes nos payloads devem atualizar este documento
+
+## Nota de sincronização documental
+Sempre que houver mudança de rota, script ou variável de ambiente, atualizar este contrato e a documentação relacionada (`README.md` e `docs/architecture.md`) no mesmo conjunto de mudanças.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ Essa decisão reduz a complexidade inicial do projeto, acelera a implementação
 
 ## Estrutura do monorepo
 ```text
-hospagenda/
+projeto-pdhc/
   backend/
   mobile/
   docs/
@@ -89,16 +89,27 @@ backend/
 ## Estrutura do mobile
 ```text
 mobile/
+  app/
+    _layout.tsx
+    index.tsx
+    auth/
+    (protected)/
   src/
-    screens/
     components/
     services/
     hooks/
-    navigation/
     types/
     utils/
     constants/
 ```
+
+## Portas e endpoints locais
+- backend NestJS: `http://127.0.0.1:3000`
+- prefixo global de rotas do backend: `/api`
+- Supabase API local: `http://127.0.0.1:54321`
+- Postgres local (Supabase): `127.0.0.1:54322`
+
+Exemplo completo de endpoint protegido no ambiente local: `http://127.0.0.1:3000/api/auth/me`.
 
 ## Módulos do backend
 ### Auth
@@ -200,3 +211,6 @@ Os status do agendamento serão:
 - sem múltiplas especialidades por profissional
 
 Esses trade-offs são intencionais e visam maximizar a qualidade do núcleo do sistema dentro do prazo disponível.
+
+## Nota de sincronização documental
+Qualquer alteração de rota, script ou variável de ambiente deve ser acompanhada de atualização imediata da documentação (`README.md`, `docs/architecture.md`, `docs/api-contract.md` e demais docs impactados).


### PR DESCRIPTION
### Motivation
- Alinhar a documentação com a estrutura atual do código para reduzir ambiguidade entre mobile e backend. 
- Garantir que a árvore do projeto e os contratos de API reflitam o uso do Expo Router e o prefixo global de rotas do backend. 
- Padronizar as portas/URLs locais para um setup de desenvolvimento consistente (backend, Supabase e Postgres). 

### Description
- Atualiza `README.md` para renomear a raiz do monorepo para `projeto-pdhc/`, documentar a estrutura mobile em padrão Expo Router (`mobile/app/...`) mantendo `mobile/src` para componentes/serviços, alterar todos os endpoints listados para o prefixo `/api` e adicionar seção de portas/URLs locais e nota de sincronização documental. 
- Atualiza `docs/architecture.md` para refletir o mesmo ajuste do nome do monorepo, a reorganização do mobile (`app/` + `src/`), adicionar portas/endpoints locais e exemplo de endpoint completo com `/api`, além da nota de sincronização documental. 
- Atualiza `docs/api-contract.md` para declarar explicitamente que todas as rotas são servidas sob o prefixo `/api`, ajustar exemplos e paths para `/api/...`, consolidar portas/URLs locais (backend `3000`, Supabase `54321`, Postgres `54322`) e incluir a nota de sincronização documental. 

### Testing
- Nenhum teste automatizado foi executado porque as mudanças são exclusivamente documentais; não há alteração de código fonte que exija execução de `npm test` ou e2e neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9592566483299c1b8cd3d0ecb0ac)