### PR TITLE
docs(mobile): atualizar README com pré-requisitos, rede e troubleshooting

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,37 +2,84 @@
 
 Aplicativo React Native (Expo Router) do projeto PDHC.
 
-## Fluxo recomendado
+## Pré-requisitos
 
-Na raiz do monorepo, use:
+- Node.js e npm instalados.
+- Expo CLI via `npx` (não é necessário instalar globalmente).
+- Emulador Android é opcional (também é possível rodar em dispositivo físico com Expo Go).
+
+## Configuração de ambiente (`.env`)
+
+1. Copie o arquivo de exemplo:
+
+```bash
+cp mobile/.env.example mobile/.env
+```
+
+2. Preencha no `mobile/.env` as variáveis obrigatórias do projeto (ex.: URL da API e credenciais públicas usadas pelo app).
+
+## Configuração de rede (obrigatório)
+
+Defina `EXPO_PUBLIC_API_URL` corretamente de acordo com onde o app vai rodar:
+
+- **Emulador Android**:
+
+```env
+EXPO_PUBLIC_API_URL=http://10.0.2.2:3000
+```
+
+- **Dispositivo físico (mesma rede LAN da sua máquina)**:
+  - Use o IP local da sua máquina, por exemplo:
+
+```env
+EXPO_PUBLIC_API_URL=http://192.168.0.10:3000
+```
+
+> `mobile/src/lib/api.ts` adiciona o sufixo `/api` automaticamente.  
+> Exemplo: se `EXPO_PUBLIC_API_URL=http://10.0.2.2:3000`, as requisições irão para `http://10.0.2.2:3000/api`.
+
+## Fluxos de execução
+
+### 1) Rodar o ambiente completo pela raiz
+
+Na raiz do monorepo:
 
 ```bash
 npm run dev
 ```
 
-Esse comando sobe:
+Esse fluxo sobe:
 
 - Supabase local
 - backend NestJS
 - mobile Expo na porta 8082
 
-## Rodar apenas o mobile
+### 2) Rodar somente o mobile
 
-Dentro da pasta mobile:
-
-```bash
-npm install
-npm run emulator
-```
-
-Para tentar abrir automaticamente no Android Emulator:
+Na raiz do monorepo:
 
 ```bash
-npm run android:emulator
+npm --prefix mobile run emulator
 ```
 
-## Estrutura inicial
+(Equivalente a entrar em `mobile/` e executar `npm run emulator`.)
 
-O app foi limpo do boilerplate padrão do create-expo-app e começa com uma tela base em:
+## Checklist de validação
 
-- app/index.tsx
+- [ ] O app inicia sem erro no emulador/dispositivo.
+- [ ] O login/autenticação funciona com as credenciais esperadas.
+- [ ] A listagem de dados do backend é carregada com sucesso no app.
+
+## Erros comuns
+
+- **Timeout da API**
+  - Verifique se backend está rodando e acessível na porta `3000`.
+  - Confirme se `EXPO_PUBLIC_API_URL` está apontando para host correto do contexto (emulador vs dispositivo físico).
+
+- **Host incorreto**
+  - Emulador Android não acessa `localhost` da mesma forma que sua máquina host.
+  - Use `10.0.2.2` no emulador ou IP LAN em dispositivo físico.
+
+- **Supabase URL incorreta**
+  - Revise variáveis do `.env` copiadas de `mobile/.env.example`.
+  - Garanta que a URL/keys utilizadas correspondem ao ambiente em execução.


### PR DESCRIPTION
### Motivation

- Facilitar o setup e execução do app móvel para desenvolvedores, removendo ambiguidades sobre variáveis de ambiente e rede.
- Evitar erros comuns ao conectar o app ao backend local (emulador Android vs dispositivo físico) e documentar os fluxos de execução suportados.

### Description

- Adiciona seção de `Pré-requisitos` detalhando uso do Expo CLI via `npx` e que o emulador Android é opcional.
- Documenta como copiar `mobile/.env.example` para `mobile/.env` e preencher as variáveis obrigatórias.
- Explica configuração de rede com exemplos para emulador Android (`EXPO_PUBLIC_API_URL=http://10.0.2.2:3000`) e para dispositivo físico usando o IP LAN da máquina, e nota que `mobile/src/lib/api.ts` adiciona o sufixo `/api` automaticamente.
- Organiza os `Fluxos de execução` para rodar o ambiente completo pela raiz com `npm run dev` e rodar apenas o mobile com `npm --prefix mobile run emulator`, além de incluir checklist de validação e seção de erros comuns (timeout da API, host incorreto, Supabase URL incorreta).

### Testing

- Verifiquei as mudanças com `git diff -- mobile/README.md` e o diff contém as adições esperadas, sem falhas.
- Visualizei o arquivo final com `nl -ba mobile/README.md | sed -n '1,220p'` para confirmar a estrutura e o conteúdo, sem erros de formatação.
- O arquivo foi commitado com sucesso usando `git commit` e o processo de geração do PR foi executado sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb958986948329a249050f8ae9190b)