### PR TITLE
docs(backend): reescreve README com setup local do PDHC

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,98 +1,128 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# Backend PDHC (NestJS)
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+Backend da aplicação **PDHC** (plataforma de agendamento hospitalar simplificado) responsável por:
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+- expor a API HTTP consumida pelo mobile;
+- validar autenticação baseada em Supabase;
+- aplicar regras de negócio de pacientes, profissionais, especialidades, consultas e dashboard;
+- persistir dados no PostgreSQL do Supabase local.
 
-## Description
+## Objetivo no contexto do PDHC
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+No MVP do PDHC, o backend concentra as responsabilidades de domínio e segurança. Ele recebe requisições autenticadas do app, valida dados de entrada, aplica regras de agendamento (como conflitos de horário) e mantém consistência dos dados hospitalares administrativos.
 
-## Project setup
+## Pré-requisitos
+
+Antes de iniciar o backend localmente, garanta que você tem:
+
+- **Node.js** (recomendado: versão LTS atual);
+- **npm** (instalado junto com Node.js);
+- **Supabase local ativo** (Auth + Postgres), com as portas padrão disponíveis.
+
+> Sem o Supabase local em execução, o backend não conseguirá validar token nem conectar ao banco.
+
+## Configuração de ambiente
+
+1. No diretório `backend/`, copie o arquivo de exemplo:
 
 ```bash
-$ npm install
+cp .env.example .env
 ```
 
-## Compile and run the project
+2. Preencha as variáveis obrigatórias:
 
-```bash
-# development
-$ npm run start
+- `NODE_ENV`: ambiente de execução (`development`, `test`, `production`).
+- `PORT`: porta HTTP do NestJS (local padrão: `3000`).
+- `CORS_ORIGIN`: origem permitida para acesso ao backend (ex.: app web/mobile em dev).
 
-# watch mode
-$ npm run start:dev
+- `SUPABASE_URL`: URL do Supabase local (padrão: `http://127.0.0.1:54321`).
+- `SUPABASE_ANON_KEY`: chave pública (publishable/anon) usada em fluxos de autenticação.
+- `SUPABASE_SERVICE_ROLE_KEY`: chave de serviço com privilégios elevados (uso apenas no backend).
+- `SUPABASE_JWT_SECRET`: segredo JWT usado para validação de tokens emitidos localmente.
 
-# production mode
-$ npm run start:prod
-```
+- `DATABASE_URL`: string de conexão PostgreSQL usada pelo Prisma (padrão local: `postgresql://postgres:postgres@127.0.0.1:54322/postgres`).
 
-## Run tests
+Referência: `backend/.env.example`.
 
-```bash
-# unit tests
-$ npm run test
+## Endereços locais
 
-# e2e tests
-$ npm run test:e2e
+Com o backend em execução:
 
-# test coverage
-$ npm run test:cov
-```
+- **API base:** `http://localhost:3000/api`
+- **Swagger (OpenAPI):** `http://localhost:3000/docs`
 
-## Deployment
+## Comandos principais
 
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+No diretório `backend/`:
 
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+### Execução e build
 
-```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
-```
+- `npm run start:dev`  
+  Inicia o servidor em modo desenvolvimento com watch. Use no dia a dia.
 
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+- `npm run build`  
+  Gera build de produção em `dist/`. Use para validar compilação antes de deploy/CI.
 
-## Resources
+### Testes
 
-Check out a few resources that may come in handy when working with NestJS:
+- `npm run test`  
+  Executa testes unitários/integrados (Jest). Use durante desenvolvimento de regras e serviços.
 
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
+- `npm run test:e2e`  
+  Executa testes end-to-end (contratos HTTP e fluxos principais). Use antes de abrir PR ou validar regressão.
 
-## Support
+### Prisma
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+- `npm run prisma:generate`  
+  Regenera o client Prisma após alteração de schema.
 
-## Stay in touch
+- `npm run prisma:validate`  
+  Valida o `schema.prisma` sem aplicar mudanças.
 
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
+- `npm run prisma:migrate:status`  
+  Mostra status das migrações entre código e banco atual.
 
-## License
+- `npm run prisma:migrate:dev`  
+  Cria/aplica migrações em ambiente local de desenvolvimento.
 
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+- `npm run prisma:migrate:deploy`  
+  Aplica migrações já versionadas (uso típico em staging/prod/CI).
+
+- `npm run prisma:studio`  
+  Abre interface visual para inspeção de dados local.
+
+## Ordem recomendada para desenvolvimento local
+
+1. **Subir o Supabase local** (Auth e Postgres disponíveis).
+2. **Instalar dependências do backend** (`npm install`, se necessário).
+3. **Configurar `.env`** a partir de `.env.example`.
+4. **Aplicar/verificar migrações** (`npm run prisma:migrate:dev` ou ao menos `npm run prisma:migrate:status`).
+5. **Iniciar o Nest** (`npm run start:dev`).
+6. (Opcional) Abrir Swagger para validar rotas.
+
+## Troubleshooting rápido
+
+### Erro de conexão com `DATABASE_URL`
+
+Sintomas comuns:
+- falha no bootstrap do Nest;
+- erro do Prisma ao conectar (`P1001`, timeout, refused).
+
+Checklist:
+- confirme se o Supabase local está ativo;
+- valide host/porta da URL (`127.0.0.1:54322` no padrão local);
+- confirme usuário/senha (`postgres/postgres` no padrão inicial);
+- rode `npm run prisma:migrate:status` para testar conectividade;
+- verifique se não há conflito de portas em outro serviço local.
+
+### Erro com chaves Supabase (`SUPABASE_*`)
+
+Sintomas comuns:
+- `401 Unauthorized` em rotas protegidas;
+- falhas ao validar token no backend.
+
+Checklist:
+- confirme se `SUPABASE_URL` aponta para a instância local correta;
+- revise `SUPABASE_ANON_KEY` e `SUPABASE_SERVICE_ROLE_KEY` sem espaços extras/quebras;
+- garanta que `SUPABASE_JWT_SECRET` corresponde ao segredo da instância local;
+- reinicie o backend após alterar variáveis de ambiente.


### PR DESCRIPTION
### Motivation

- Substituir o boilerplate genérico do NestJS no `backend/README.md` por documentação prática e específica para o fluxo local do PDHC. 
- Fornecer instruções claras para iniciar o backend com Supabase local e deixar explícito o significado das variáveis de ambiente usadas pelo projeto. 
- Reduzir atrito no desenvolvimento local ao documentar comandos principais, endereços locais e troubleshooting rápido para problemas comuns (DB e chaves Supabase).

### Description

- Remove o conteúdo boilerplate do Nest e adiciona um README focado no PDHC com objetivo do backend e responsabilidades no MVP. 
- Documenta pré-requisitos, passo a passo para criar `backend/.env` a partir de `backend/.env.example` e descreve o significado de `NODE_ENV`, `PORT`, `CORS_ORIGIN`, `SUPABASE_*` e `DATABASE_URL`. 
- Lista os comandos principais (`npm run start:dev`, `npm run build`, `npm run test`, `npm run test:e2e`, `npm run prisma:*`) com orientações de quando usar cada um e expõe os endereços locais `http://localhost:3000/api` (API base) e `http://localhost:3000/docs` (Swagger). 
- Adiciona ordem recomendada para desenvolvimento local (subir Supabase -> aplicar migrações -> iniciar Nest) e uma seção de troubleshooting para erros de `DATABASE_URL` e problemas com chaves `SUPABASE_*`.

### Testing

- Validação de workspace via `git -C /workspace/projeto-pdhc status --short` foi executada com sucesso. 
- Commit da alteração (`docs(backend): reescreve README com guia local do PDHC`) foi criado com sucesso and `git -C /workspace/projeto-pdhc rev-parse --short HEAD` retornou a revisão atual com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9577d65483299df1eb18e15b85dc)