### PR TITLE
fix(dashboard): filtra agenda para exibir apenas próximos atendimentos ativos

### DIFF
--- a/backend/src/modules/dashboard/dashboard.service.spec.ts
+++ b/backend/src/modules/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { BadRequestException } from '@nestjs/common';
+import { AppointmentStatus } from '@prisma/client';
+import { DashboardService } from './dashboard.service';
+import type { PrismaService } from '../../lib/prisma/prisma.service';
+
+type GroupByResult = Array<{
+  status: AppointmentStatus;
+  _count: { id: number };
+}>;
+
+function buildMockPrisma() {
+  return {
+    appointment: {
+      groupBy: jest.fn<(...args: unknown[]) => Promise<GroupByResult>>(),
+      findMany: jest.fn<(...args: unknown[]) => Promise<unknown[]>>(),
+    },
+  };
+}
+
+type MockPrisma = ReturnType<typeof buildMockPrisma>;
+
+function buildService(prisma: MockPrisma) {
+  return new DashboardService(prisma as unknown as PrismaService);
+}
+
+describe('DashboardService', () => {
+  let prisma: MockPrisma;
+  let service: DashboardService;
+
+  beforeEach(() => {
+    prisma = buildMockPrisma();
+    service = buildService(prisma);
+    jest.clearAllMocks();
+
+    jest.mocked(prisma.appointment.groupBy).mockResolvedValue([]);
+    jest.mocked(prisma.appointment.findMany).mockResolvedValue([]);
+  });
+
+  it('throws BadRequestException when date format is invalid', async () => {
+    await expect(service.getTodayMetrics('24-04-2026')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('requests only active upcoming appointments for the selected day', async () => {
+    await service.getTodayMetrics('2026-04-10');
+
+    expect(prisma.appointment.findMany).toHaveBeenCalledTimes(1);
+    const [firstCall] = jest.mocked(prisma.appointment.findMany).mock.calls;
+    const where = firstCall?.[0]?.where;
+
+    expect(where).toEqual({
+      startAt: {
+        gte: new Date('2026-04-10T00:00:00.000Z'),
+        lte: new Date('2026-04-10T23:59:59.999Z'),
+      },
+      status: {
+        in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED],
+      },
+    });
+  });
+
+  it('aggregates totals by appointment status', async () => {
+    jest.mocked(prisma.appointment.groupBy).mockResolvedValue([
+      { status: AppointmentStatus.SCHEDULED, _count: { id: 3 } },
+      { status: AppointmentStatus.CONFIRMED, _count: { id: 1 } },
+      { status: AppointmentStatus.CANCELLED, _count: { id: 2 } },
+    ]);
+
+    const result = await service.getTodayMetrics('2026-04-24');
+
+    expect(result.metrics).toEqual({
+      total: 6,
+      SCHEDULED: 3,
+      CONFIRMED: 1,
+      COMPLETED: 0,
+      CANCELLED: 2,
+    });
+  });
+});

--- a/backend/src/modules/dashboard/dashboard.service.ts
+++ b/backend/src/modules/dashboard/dashboard.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
+import { AppointmentStatus } from '@prisma/client';
 import { PrismaService } from '../../lib/prisma/prisma.service';
 
 @Injectable()
@@ -63,11 +64,28 @@ export class DashboardService {
       }
     }
 
-    // 2. Fetch upcoming appointments (ignoring cancelled/completed if we want,
-    // but the spec says "próximos agendamentos do dia", it's good to list all or at least scheduled/confirmed)
-    // Let's bring all appointments for today so the user sees the full agenda
+    // 2. Fetch only upcoming appointments for the selected day.
+    // For "today", this excludes earlier slots that already happened.
+    const now = new Date();
+    const isCurrentUtcDay =
+      baseDate.getUTCFullYear() === now.getUTCFullYear() &&
+      baseDate.getUTCMonth() === now.getUTCMonth() &&
+      baseDate.getUTCDate() === now.getUTCDate();
+
+    const upcomingStart = isCurrentUtcDay
+      ? new Date(Math.max(now.getTime(), startOfDay.getTime()))
+      : startOfDay;
+
     const upcomingAppointments = await this.prisma.appointment.findMany({
-      where: whereClause,
+      where: {
+        startAt: {
+          gte: upcomingStart,
+          lte: endOfDay,
+        },
+        status: {
+          in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED],
+        },
+      },
       orderBy: {
         startAt: 'asc',
       },


### PR DESCRIPTION
### Motivation
- Corrigir comportamento da lista `upcomingAppointments` que estava retornando todos os agendamentos do dia, incluindo horários já passados e status não ativos, causando inconsistência com a intenção de exibir apenas "próximos" atendimentos.

### Description
- Atualiza `DashboardService` para filtrar `upcomingAppointments` por `status` (`SCHEDULED` e `CONFIRMED`) e por `startAt` entre o início do dia e `endOfDay`.
- Para o dia atual (UTC) define o limite inferior como o horário atual para excluir slots já passados; para outros dias usa o início do dia como limite inferior.
- Adiciona import de `AppointmentStatus` e cria testes unitários em `backend/src/modules/dashboard/dashboard.service.spec.ts` cobrindo validação de formato de data, filtro de próximos atendimentos ativos e agregação de métricas por status.

### Testing
- Executado `DATABASE_URL='postgresql://user:pass@localhost:5432/db' npx prisma generate` com sucesso para gerar o client Prisma.
- Executado `cd backend && npm test -- --runInBand` e todos os testes do backend passaram (`6` suítes, `43` testes).
- Executado `cd mobile && npm test -- --runInBand` anteriormente e os testes do mobile passaram (`2` suítes, `3` testes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9235ddfc8329a6f3dd50627244b9)