### PR TITLE
docs: alinhar e consolidar documentação do monorepo PDHC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,356 +1,117 @@
 # Projeto PDHC
 
-Aplicação mobile de agendamento hospitalar simplificado, voltada ao uso administrativo, com backend em NestJS, autenticação via Supabase local, cadastro de pacientes, profissionais e especialidades, além de criação e gerenciamento de consultas com regras de negócio, documentação e testes.
+Aplicação mobile de agendamento hospitalar simplificado para uso administrativo, com backend em NestJS, autenticação via Supabase local e fluxo completo de cadastros + consultas.
 
-## Objetivo
+## Status atual do projeto
 
-Este projeto foi pensado para demonstrar:
+O MVP está implementado com:
 
-- arquitetura backend organizada e escalável
-- integração entre React Native, NestJS e Supabase
-- modelagem de domínio aderente a um cenário hospitalar
-- boas práticas de documentação, testes e gestão de projeto
-- foco em fluxo administrativo realista, sem complexidade clínica desnecessária
-
-## Escopo do MVP
-
-### Incluído
-
-- autenticação com Supabase Auth em ambiente local
-- validação do token no backend NestJS
-- cadastro e listagem de especialidades
-- cadastro, edição, detalhe e listagem de profissionais
-- cadastro, edição, detalhe e listagem de pacientes
-- criação, listagem, detalhe e gerenciamento de agendamentos
-- ações de confirmar, remarcar, cancelar e concluir consulta
-- dashboard simples do dia
-- filtros por data, status, profissional e especialidade
-- documentação técnica
-- testes estratégicos no backend
-- organização via GitHub Projects, issues e sub-issues
-
-### Fora do escopo
-
-- portal do paciente
-- múltiplos perfis de acesso
-- prontuário clínico
-- notificações
-- tempo real
-- integração com sistemas externos
-- exclusão física de registros
-
-## Público-alvo
-
-Equipe administrativa hospitalar responsável por cadastrar pacientes, manter profissionais e organizar a agenda de atendimentos.
+- autenticação (sign in / sign up no app + validação de token no backend)
+- CRUD essencial de especialidades, profissionais e pacientes
+- criação e gestão de consultas (confirmar, remarcar, cancelar, concluir)
+- dashboard diário com resumo operacional
+- documentação funcional e técnica em `docs/`
+- testes automatizados no backend
 
 ## Stack
 
-### Mobile
-- React Native
-- Expo
-- TypeScript
+- **Mobile:** React Native + Expo Router + TypeScript
+- **Backend:** NestJS + Prisma + PostgreSQL
+- **Auth/DB local:** Supabase CLI (Auth + Postgres)
+- **Qualidade:** ESLint, Prettier, Jest, Swagger/OpenAPI
 
-### Backend
-- NestJS
-- TypeScript
-- PostgreSQL (via Supabase local)
-- Swagger / OpenAPI
-- Jest
-
-### Infra e produtividade
-- Docker
-- Supabase CLI
-- GitHub Projects
-- GitHub Actions
-- ESLint
-- Prettier
-
-## Setup local rápido
-
-1. `cp .env.example .env`
-2. `npm run setup`
-3. `npm run supabase:start`
-4. `npm run dev`
-
-### Variáveis Supabase (referência do `supabase status`)
-
-| Nome no `supabase status` | Nome no `.env` raiz | Serviço consumidor | Obrigatório? |
-| --- | --- | --- | --- |
-| API URL | `SUPABASE_URL` | backend e mobile | obrigatório |
-| anon key | `SUPABASE_ANON_KEY` | backend e mobile | obrigatório |
-| service_role key | `SUPABASE_SERVICE_ROLE_KEY` | backend | obrigatório |
-| JWT secret | `SUPABASE_JWT_SECRET` | backend | obrigatório |
-| DB URL | `DATABASE_URL` | backend | obrigatório |
-| _(não vem do Supabase status)_ | `EXPO_PUBLIC_APP_ENV` | mobile | opcional |
-
-> Observação: no mobile, use os equivalentes `EXPO_PUBLIC_SUPABASE_URL` e `EXPO_PUBLIC_SUPABASE_ANON_KEY` no `.env` de `mobile/` para apontar para o host correto (emulador/dispositivo físico).
-
-## Arquitetura
-
-```text
-mobile (React Native + Expo)
-        |
-        | Bearer Token
-        v
-backend (NestJS + regras de negócio)
-        |
-        v
-PostgreSQL + Auth (Supabase local)
-```
-
-### Decisões principais
-- autenticação delegada ao Supabase para reduzir complexidade inicial
-- backend NestJS focado em domínio, validação, regras e contratos de API
-- duração fixa implícita de 30 minutos por consulta
-- uma especialidade por profissional no MVP
-- cancelamento por mudança de status, preservando histórico
-
-## Entidades principais
-
-### Specialty
-- id
-- name
-- createdAt
-
-### Professional
-- id
-- fullName
-- specialtyId
-- createdAt
-- updatedAt
-
-### Patient
-- id
-- fullName
-- cpf
-- birthDate
-- phone
-- createdAt
-- updatedAt
-
-### Appointment
-- id
-- patientId
-- professionalId
-- specialtyId
-- startAt
-- status
-- notes
-- createdAt
-- updatedAt
-
-### Status do agendamento
-- SCHEDULED
-- CONFIRMED
-- CANCELLED
-- COMPLETED
-
-## Regras de negócio
-
-- não permitir agendamento no passado
-- não permitir conflito de horário para o mesmo profissional
-- cada profissional pertence a uma única especialidade
-- toda consulta deve estar associada a paciente e profissional válidos
-- a especialidade do agendamento deve corresponder à do profissional
-- cancelamento preserva histórico
-- remarcação revalida conflito e data
-- conclusão só pode ocorrer em consulta ativa
-- toda consulta possui duração implícita de 30 minutos
-
-## Estrutura do repositório
+## Estrutura do monorepo
 
 ```text
 projeto-pdhc/
-  backend/
-  mobile/
-  docs/
-  .github/
+  backend/      # API NestJS + Prisma + Swagger
+  mobile/       # App Expo/React Native
+  docs/         # documentação de produto, arquitetura, API e testes
+  scripts/      # automações utilitárias (ex.: sync de env do mobile)
 ```
 
-## Estrutura esperada do backend
+## Setup rápido (recomendado)
 
-```text
-backend/
-  src/
-    modules/
-      auth/
-      specialties/
-      professionals/
-      patients/
-      appointments/
-      dashboard/
-    common/
+1. Copie o arquivo de ambiente da raiz:
+
+```bash
+cp .env.example .env
 ```
 
-## Estrutura esperada do mobile
+2. Instale dependências:
 
-```text
-mobile/
-  app/
-    _layout.tsx
-    index.tsx
-    auth/
-    (protected)/
-  src/
-    components/
-    services/
-    hooks/
-    types/
-    utils/
-    constants/
+```bash
+npm run setup
 ```
 
-## Endpoints do MVP
+3. Suba backend + mobile (Android Emulator):
 
-### Auth
+```bash
+npm run dev
+```
+
+> `npm run dev` executa: Supabase local + backend + mobile (porta 8082), com sync automático do `mobile/.env`.
+
+## Variáveis de ambiente (fonte única)
+
+A **fonte de verdade** é o arquivo `.env` na raiz. O script `npm run sync:mobile-env` gera `mobile/.env` contendo apenas variáveis `EXPO_PUBLIC_*`.
+
+### Obrigatórias no `.env`
+
+| Variável                        | Uso                                                 |
+| ------------------------------- | --------------------------------------------------- |
+| `SUPABASE_URL`                  | Backend (validação de token)                        |
+| `SUPABASE_ANON_KEY`             | Backend e mobile                                    |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Backend                                             |
+| `SUPABASE_JWT_SECRET`           | Backend                                             |
+| `DATABASE_URL`                  | Prisma / backend                                    |
+| `EXPO_PUBLIC_SUPABASE_URL`      | Mobile                                              |
+| `EXPO_PUBLIC_SUPABASE_ANON_KEY` | Mobile                                              |
+| `EXPO_PUBLIC_API_URL`           | Mobile (sem `/api`, o app adiciona automaticamente) |
+
+### Exemplo de `EXPO_PUBLIC_API_URL`
+
+- Android Emulator: `http://10.0.2.2:3000`
+- Dispositivo físico (mesma LAN): `http://192.168.x.x:3000`
+
+## Endpoints principais do MVP
+
+Todos sob prefixo global `/api`.
+
 - `GET /api/auth/me`
-
-### Specialties
-- `POST /api/specialties`
-- `GET /api/specialties`
-
-### Professionals
-- `POST /api/professionals`
-- `GET /api/professionals`
-- `GET /api/professionals/:id`
-- `PATCH /api/professionals/:id`
-
-### Patients
-- `POST /api/patients`
-- `GET /api/patients`
-- `GET /api/patients/:id`
-- `PATCH /api/patients/:id`
-
-### Appointments
-- `POST /api/appointments`
-- `GET /api/appointments`
-- `GET /api/appointments/:id`
-- `PATCH /api/appointments/:id/confirm`
-- `PATCH /api/appointments/:id/reschedule`
-- `PATCH /api/appointments/:id/cancel`
-- `PATCH /api/appointments/:id/complete`
-
-### Dashboard
+- `POST/GET /api/specialties`
+- `POST/GET /api/professionals`, `GET/PATCH /api/professionals/:id`
+- `POST/GET /api/patients`, `GET/PATCH /api/patients/:id`
+- `POST/GET /api/appointments`, `GET /api/appointments/:id`
+- `PATCH /api/appointments/:id/{confirm|reschedule|cancel|complete}`
 - `GET /api/dashboard/today`
 
-## Portas e URLs locais
+Swagger local: `http://localhost:3000/docs`
 
-- backend NestJS: `http://127.0.0.1:3000` com prefixo global `api`
-- Supabase API local: `http://127.0.0.1:54321`
-- Postgres local (Supabase): `127.0.0.1:54322`
+## Scripts úteis (raiz)
 
-## Nota de sincronização documental
+- `npm run dev` → Supabase + backend + mobile (emulador)
+- `npm run dev:all` → Supabase + backend + mobile (modo start padrão)
+- `npm run dev:services` → Supabase + backend
+- `npm run dev:backend` → apenas backend
+- `npm run dev:mobile` → apenas mobile
+- `npm run supabase:start|status|stop`
+- `npm run lint`, `npm run typecheck`, `npm run test`, `npm run test:e2e`
 
-Sempre que houver mudança de rota, script ou variável de ambiente, atualize `README.md` e os arquivos em `docs/` no mesmo ciclo de alteração para manter contrato, arquitetura e setup alinhados.
+## Documentação detalhada
 
-## Fluxos principais
+- visão de produto: `docs/product-overview.md`
+- arquitetura: `docs/architecture.md`
+- contrato da API: `docs/api-contract.md`
+- estratégia de testes: `docs/testing-strategy.md`
+- plano de entrega: `docs/delivery-plan.md`
+- guia interno de execução: `docs/internal-execution-guide.md`
 
-1. usuário administrativo autentica no app
-2. app recebe token do Supabase
-3. app envia token para API NestJS
-4. backend valida o token e libera rotas protegidas
-5. usuário cadastra paciente, profissional e especialidade
-6. usuário cria e gerencia agendamentos
-7. dashboard apresenta o resumo operacional do dia
+## Regra de manutenção da documentação
 
-## Estratégia de testes
+Qualquer mudança de rota, payload, script ou variável de ambiente deve atualizar no mesmo PR:
 
-### Unitários
-- criação de consulta válida
-- bloqueio de consulta no passado
-- bloqueio de conflito de horário
-- confirmação, cancelamento e conclusão de consulta
-- remarcação com revalidação das regras
-
-### Integração
-- rota protegida com token válido
-- criação de consulta autenticada
-- erro em conflito de horário
-- listagem com filtro por data
-
-## Gestão do projeto
-
-O projeto será organizado com:
-- GitHub Projects
-- parent issues por fase e área
-- sub-issues por tarefa executável
-- pipeline inicial com GitHub Actions para lint, build e testes
-
-## Documentação planejada
-
-- `docs/product-overview.md`
+- `README.md`
 - `docs/architecture.md`
 - `docs/api-contract.md`
-- `docs/testing-strategy.md`
-- `docs/delivery-plan.md`
-- `docs/internal-execution-guide.md`
-
-## Roadmap pós-MVP
-
-- portal do paciente
-- cancelamento pelo paciente
-- múltiplos perfis de acesso
-- disponibilidade médica avançada
-- notificações
-- integração com calendário
-- dashboard mais analítico
-
-## Como rodar o projeto (passo a passo)
-
-### Pré-requisitos
-- Node.js
-- Docker
-- Supabase CLI
-- Expo CLI ou ambiente equivalente
-- npm ou pnpm
-
-### Etapas gerais
-1. subir o Supabase local
-2. configurar variáveis de ambiente do backend (colocar dentro da pasta config) e mobile
-3. iniciar o backend NestJS
-4. iniciar o app mobile
-5. autenticar e validar o fluxo ponta a ponta
-
-### Mapeamento de variáveis do Supabase
-
-Para evitar ambiguidade entre os nomes exibidos pela Supabase CLI e os nomes usados no projeto, utilize o mapeamento abaixo:
-
-| Origem (Supabase CLI) | Variável no projeto | Onde usar |
-| --- | --- | --- |
-| `anon key` / `ANON_KEY` | `SUPABASE_ANON_KEY` | backend |
-| `anon key` / `ANON_KEY` | `EXPO_PUBLIC_SUPABASE_ANON_KEY` | mobile (Expo) |
-
-> Observação: durante o desenvolvimento mobile, a API deve ser consumida pelo IP da máquina hospedeira, e não por `localhost`, quando o app estiver rodando em dispositivo físico.
-
-### Scripts iniciais (raiz)
-
-- `npm run setup`: instala dependências de backend e mobile
-- `npm run dev` ou `npm run dev:all`: sobe Supabase local e roda backend + mobile juntos
-- `npm run dev:android`: sobe Supabase local e roda backend + mobile no Android Emulator
-- `npm run dev:services`: sobe Supabase local e roda apenas backend (ideal para Swagger)
-- `npm run dev:backend`: inicia backend em modo watch
-- `npm run dev:mobile`: inicia app mobile
-- `npm run dev:mobile:emulator`: inicia app mobile direto no Android Emulator
-- `npm run dev:mobile:android`: tenta abrir o app automaticamente no Android Emulator
-- `npm run supabase:start`: sobe os containers do Supabase local
-- `npm run supabase:status`: exibe status e credenciais locais do Supabase
-- `npm run supabase:stop`: para os containers do Supabase local
-- `npm run lint`: executa lint em backend e mobile
-- `npm run format`: aplica Prettier em backend e mobile
-- `npm run format:check`: valida formatação em backend e mobile
-- `npm run typecheck`: valida TypeScript em backend e mobile
-- `npm run test`: executa testes unitários do backend
-- `npm run test:e2e`: executa testes e2e do backend
-
-### Fluxo recomendado (Android Studio)
-
-1. `npm run dev:services`
-2. abrir Swagger no backend (`http://localhost:3000/docs`)
-3. em outro terminal, `npm run dev:mobile:emulator`
-4. com o emulador já aberto, pressione `a` no terminal do Expo (ou use `npm run dev:mobile:android`)
-
-> No Android Emulator, o app usa `10.0.2.2` para acessar serviços do host (`backend` e `supabase`).
-
-## Autor
-
-Projeto desenvolvido como entrega técnica para processo seletivo, com foco em demonstrar domínio de backend, integração full stack, testes, documentação e organização de engenharia.
+- README do módulo impactado (`backend/README.md` e/ou `mobile/README.md`)

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,128 +1,71 @@
 # Backend PDHC (NestJS)
 
-Backend da aplicação **PDHC** (plataforma de agendamento hospitalar simplificado) responsável por:
-
-- expor a API HTTP consumida pelo mobile;
-- validar autenticação baseada em Supabase;
-- aplicar regras de negócio de pacientes, profissionais, especialidades, consultas e dashboard;
-- persistir dados no PostgreSQL do Supabase local.
-
-## Objetivo no contexto do PDHC
-
-No MVP do PDHC, o backend concentra as responsabilidades de domínio e segurança. Ele recebe requisições autenticadas do app, valida dados de entrada, aplica regras de agendamento (como conflitos de horário) e mantém consistência dos dados hospitalares administrativos.
+API do projeto PDHC responsável por autenticação (validação de token), regras de negócio e persistência dos módulos de especialidades, profissionais, pacientes, consultas e dashboard.
 
 ## Pré-requisitos
 
-Antes de iniciar o backend localmente, garanta que você tem:
-
-- **Node.js** (recomendado: versão LTS atual);
-- **npm** (instalado junto com Node.js);
-- **Supabase local ativo** (Auth + Postgres), com as portas padrão disponíveis.
-
-> Sem o Supabase local em execução, o backend não conseguirá validar token nem conectar ao banco.
+- Node.js LTS
+- npm
+- Supabase local ativo (`npx supabase start`)
 
 ## Configuração de ambiente
 
-1. No diretório `backend/`, copie o arquivo de exemplo:
+A configuração é centralizada no `.env` da **raiz do monorepo**.
+
+1. Na raiz do projeto:
 
 ```bash
 cp .env.example .env
 ```
 
-2. Preencha as variáveis obrigatórias:
+2. Preencha as variáveis usadas pelo backend:
 
-- `NODE_ENV`: ambiente de execução (`development`, `test`, `production`).
-- `PORT`: porta HTTP do NestJS (local padrão: `3000`).
-- `CORS_ORIGIN`: origem permitida para acesso ao backend (ex.: app web/mobile em dev).
-
-- `SUPABASE_URL`: URL do Supabase local (padrão: `http://127.0.0.1:54321`).
-- `SUPABASE_ANON_KEY`: chave pública (publishable/anon) usada em fluxos de autenticação.
-- `SUPABASE_SERVICE_ROLE_KEY`: chave de serviço com privilégios elevados (uso apenas no backend).
-- `SUPABASE_JWT_SECRET`: segredo JWT usado para validação de tokens emitidos localmente.
-
-- `DATABASE_URL`: string de conexão PostgreSQL usada pelo Prisma (padrão local: `postgresql://postgres:postgres@127.0.0.1:54322/postgres`).
-
-Referência: `backend/.env.example`.
+- `PORT`
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_JWT_SECRET`
+- `DATABASE_URL`
 
 ## Endereços locais
 
-Com o backend em execução:
-
-- **API base:** `http://localhost:3000/api`
-- **Swagger (OpenAPI):** `http://localhost:3000/docs`
+- API base: `http://localhost:3000/api`
+- Swagger: `http://localhost:3000/docs`
 
 ## Comandos principais
 
-No diretório `backend/`:
+No diretório raiz:
 
-### Execução e build
+- `npm run dev:backend` — sobe backend em watch
+- `npm run build:backend` — build de produção
+- `npm run test:backend` — testes backend (Jest)
+- `npm run test:e2e` — testes e2e
 
-- `npm run start:dev`  
-  Inicia o servidor em modo desenvolvimento com watch. Use no dia a dia.
+No diretório `backend/` (se preferir execução direta):
 
-- `npm run build`  
-  Gera build de produção em `dist/`. Use para validar compilação antes de deploy/CI.
+- `npm run start:dev`
+- `npm run build`
+- `npm run test`
+- `npm run test:e2e`
+- `npm run prisma:migrate:status`
+- `npm run prisma:migrate:dev`
+- `npm run prisma:studio`
 
-### Testes
+## Fluxo recomendado
 
-- `npm run test`  
-  Executa testes unitários/integrados (Jest). Use durante desenvolvimento de regras e serviços.
-
-- `npm run test:e2e`  
-  Executa testes end-to-end (contratos HTTP e fluxos principais). Use antes de abrir PR ou validar regressão.
-
-### Prisma
-
-- `npm run prisma:generate`  
-  Regenera o client Prisma após alteração de schema.
-
-- `npm run prisma:validate`  
-  Valida o `schema.prisma` sem aplicar mudanças.
-
-- `npm run prisma:migrate:status`  
-  Mostra status das migrações entre código e banco atual.
-
-- `npm run prisma:migrate:dev`  
-  Cria/aplica migrações em ambiente local de desenvolvimento.
-
-- `npm run prisma:migrate:deploy`  
-  Aplica migrações já versionadas (uso típico em staging/prod/CI).
-
-- `npm run prisma:studio`  
-  Abre interface visual para inspeção de dados local.
-
-## Ordem recomendada para desenvolvimento local
-
-1. **Subir o Supabase local** (Auth e Postgres disponíveis).
-2. **Instalar dependências do backend** (`npm install`, se necessário).
-3. **Configurar `.env`** a partir de `.env.example`.
-4. **Aplicar/verificar migrações** (`npm run prisma:migrate:dev` ou ao menos `npm run prisma:migrate:status`).
-5. **Iniciar o Nest** (`npm run start:dev`).
-6. (Opcional) Abrir Swagger para validar rotas.
+1. `npm run supabase:start`
+2. `npm run dev:backend`
+3. acessar `http://localhost:3000/docs`
 
 ## Troubleshooting rápido
 
-### Erro de conexão com `DATABASE_URL`
+### 401 em rota protegida
 
-Sintomas comuns:
-- falha no bootstrap do Nest;
-- erro do Prisma ao conectar (`P1001`, timeout, refused).
+- confirmar envio de `Authorization: Bearer <token>`
+- validar `SUPABASE_URL`, `SUPABASE_ANON_KEY` e `SUPABASE_JWT_SECRET`
 
-Checklist:
-- confirme se o Supabase local está ativo;
-- valide host/porta da URL (`127.0.0.1:54322` no padrão local);
-- confirme usuário/senha (`postgres/postgres` no padrão inicial);
-- rode `npm run prisma:migrate:status` para testar conectividade;
-- verifique se não há conflito de portas em outro serviço local.
+### erro de banco (Prisma)
 
-### Erro com chaves Supabase (`SUPABASE_*`)
-
-Sintomas comuns:
-- `401 Unauthorized` em rotas protegidas;
-- falhas ao validar token no backend.
-
-Checklist:
-- confirme se `SUPABASE_URL` aponta para a instância local correta;
-- revise `SUPABASE_ANON_KEY` e `SUPABASE_SERVICE_ROLE_KEY` sem espaços extras/quebras;
-- garanta que `SUPABASE_JWT_SECRET` corresponde ao segredo da instância local;
-- reinicie o backend após alterar variáveis de ambiente.
+- confirmar Supabase ativo
+- validar `DATABASE_URL` com porta `54322`
+- rodar `npm --prefix backend run prisma:migrate:status`

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,115 +1,102 @@
 # API Contract
 
 ## Convenções gerais
-### Base URL
-A URL base será definida por ambiente. Em desenvolvimento local:
 
-- backend NestJS: `http://127.0.0.1:3000`
-- prefixo global obrigatório das rotas da API: `/api`
-- Supabase API local: `http://127.0.0.1:54321`
-- Postgres local (Supabase): `127.0.0.1:54322`
+### Base local
 
-Em dispositivo físico, o mobile deve usar o IP da máquina na LAN, preservando porta e prefixo (ex.: `http://192.168.0.10:3000/api`).
+- API backend: `http://127.0.0.1:3000`
+- Prefixo global: `/api`
+- Swagger: `http://127.0.0.1:3000/docs`
 
-### Prefixo de rotas
-Todas as rotas deste contrato são servidas sob o prefixo `/api`.
-
-Exemplos:
-- `/api/auth/me`
-- `/api/patients`
-- `/api/appointments/:id/confirm`
+Em dispositivo físico, use o IP da máquina na LAN para `EXPO_PUBLIC_API_URL` (ex.: `http://192.168.0.10:3000`). O mobile adiciona `/api` automaticamente.
 
 ### Autenticação
-As rotas protegidas exigem bearer token no header:
+
+Rotas protegidas exigem header:
 
 ```http
 Authorization: Bearer <access_token>
 ```
 
-O token será emitido pelo Supabase Auth e validado pela API NestJS.
+O token é emitido pelo Supabase Auth e validado pela API NestJS.
 
-### Formato de resposta
-O projeto pode adotar resposta direta por recurso ou um padrão padronizado. Para o MVP, a prioridade é manter consistência simples e clareza.
+### Erros (padrão NestJS)
+
+```json
+{
+  "statusCode": 409,
+  "message": "The selected professional already has an appointment in this time slot.",
+  "error": "Conflict"
+}
+```
 
 ## Auth
-### GET `/api/auth/me`
-Retorna os dados básicos do usuário autenticado.
 
-#### Resposta esperada
+### GET `/api/auth/me`
+
+Retorna dados do usuário autenticado extraídos do token.
+
 ```json
 {
   "id": "user-id",
-  "email": "user@example.com"
+  "email": "user@example.com",
+  "role": "authenticated",
+  "appMetadata": {},
+  "userMetadata": {}
 }
 ```
 
 ## Specialties
-### POST `/api/specialties`
-Cria uma nova especialidade.
 
-#### Request body
+### POST `/api/specialties`
+
 ```json
 {
   "name": "Cardiologia"
 }
 ```
 
-#### Regras
-- nome é obrigatório
-- nome deve ser válido e não vazio
+Regras:
+
+- `name` obrigatório
+- nome único
 
 ### GET `/api/specialties`
-Lista especialidades cadastradas.
 
-#### Resposta esperada
-```json
-[
-  {
-    "id": "specialty-id",
-    "name": "Cardiologia",
-    "createdAt": "2026-04-18T10:00:00.000Z"
-  }
-]
-```
+Lista especialidades.
 
 ## Professionals
-### POST `/api/professionals`
-Cria um profissional.
 
-#### Request body
+### POST `/api/professionals`
+
 ```json
 {
-  "fullName": "Dr. João Silva",
+  "fullName": "Dra. Ana Lima",
   "specialtyId": "specialty-id"
 }
 ```
 
-#### Regras
-- nome é obrigatório
+Regras:
+
+- `fullName` obrigatório
 - `specialtyId` deve existir
-- um profissional possui apenas uma especialidade
 
 ### GET `/api/professionals`
+
 Lista profissionais.
 
 ### GET `/api/professionals/:id`
-Retorna detalhes de um profissional.
+
+Detalha profissional.
 
 ### PATCH `/api/professionals/:id`
-Edita dados do profissional.
 
-#### Request body
-```json
-{
-  "fullName": "Dr. João Pedro Silva"
-}
-```
+Atualiza nome e/ou especialidade.
 
 ## Patients
-### POST `/api/patients`
-Cria um paciente.
 
-#### Request body
+### POST `/api/patients`
+
 ```json
 {
   "fullName": "Maria de Souza",
@@ -119,26 +106,27 @@ Cria um paciente.
 }
 ```
 
-#### Regras
-- nome é obrigatório
-- CPF deve ter formato válido conforme a regra escolhida no MVP
-- data de nascimento é obrigatória
-- telefone é obrigatório no MVP apenas se isso fizer sentido no fluxo
+Regras:
+
+- campos obrigatórios: `fullName`, `cpf`, `birthDate`, `phone`
+- `cpf` deve ser único
 
 ### GET `/api/patients`
+
 Lista pacientes.
 
 ### GET `/api/patients/:id`
-Retorna detalhes de um paciente.
+
+Detalha paciente.
 
 ### PATCH `/api/patients/:id`
-Edita dados do paciente.
+
+Atualiza paciente.
 
 ## Appointments
-### POST `/api/appointments`
-Cria um agendamento.
 
-#### Request body
+### POST `/api/appointments`
+
 ```json
 {
   "patientId": "patient-id",
@@ -148,125 +136,86 @@ Cria um agendamento.
 }
 ```
 
-#### Regras
-- `patientId` deve existir
-- `professionalId` deve existir
-- não permitir agendamento no passado
-- não permitir conflito de horário para o mesmo profissional
-- `specialtyId` pode ser derivado do profissional no backend
+Regras:
 
-#### Resposta esperada
-```json
-{
-  "id": "appointment-id",
-  "patientId": "patient-id",
-  "professionalId": "professional-id",
-  "specialtyId": "specialty-id",
-  "startAt": "2026-04-20T14:00:00.000Z",
-  "status": "SCHEDULED",
-  "notes": "Primeira consulta",
-  "createdAt": "2026-04-18T12:00:00.000Z",
-  "updatedAt": "2026-04-18T12:00:00.000Z"
-}
-```
+- `patientId` e `professionalId` devem existir
+- não permitir horário no passado
+- não permitir conflito para o mesmo profissional
+- `specialtyId` é derivado do profissional
 
 ### GET `/api/appointments`
-Lista agendamentos.
 
-#### Filtros suportados
-- `date`
+Lista com filtros opcionais:
+
+- `date` (`YYYY-MM-DD`)
 - `status`
 - `professionalId`
 - `specialtyId`
 
-#### Exemplo
+Exemplo:
+
 ```http
-GET /api/appointments?date=2026-04-20&status=SCHEDULED&professionalId=professional-id
+GET /api/appointments?date=2026-04-20&status=SCHEDULED
 ```
 
 ### GET `/api/appointments/:id`
-Retorna detalhes de um agendamento.
+
+Detalha agendamento.
 
 ### PATCH `/api/appointments/:id/confirm`
-Confirma um agendamento.
 
-#### Regras
-- só pode confirmar consulta ativa
-- não faz sentido confirmar consulta cancelada ou concluída
+Confirma consulta em `SCHEDULED`.
 
 ### PATCH `/api/appointments/:id/reschedule`
-Remarca um agendamento.
 
-#### Request body
 ```json
 {
   "startAt": "2026-04-21T10:30:00.000Z"
 }
 ```
 
-#### Regras
-- deve validar novamente data futura
-- deve validar novamente conflito de horário
+Revalida data e conflito.
 
 ### PATCH `/api/appointments/:id/cancel`
-Cancela um agendamento.
 
-#### Regras
-- não remove o registro fisicamente
-- apenas altera o status para `CANCELLED`
+Marca como `CANCELLED`.
 
 ### PATCH `/api/appointments/:id/complete`
-Conclui um agendamento.
 
-#### Regras
-- só pode concluir consulta não cancelada
+Marca como `COMPLETED` (somente consulta ativa).
 
 ## Dashboard
-### GET `/api/dashboard/today`
-Retorna resumo dos atendimentos do dia.
 
-#### Exemplo de resposta
+### GET `/api/dashboard/today`
+
+Parâmetro opcional:
+
+- `date` (`YYYY-MM-DD`) — se omitido, usa o dia atual do servidor.
+
+Exemplo:
+
+```http
+GET /api/dashboard/today?date=2026-04-21
+```
+
+Exemplo de resposta:
+
 ```json
 {
-  "date": "2026-04-18",
+  "date": "2026-04-21",
   "scheduled": 8,
   "confirmed": 4,
   "cancelled": 1,
   "completed": 2,
-  "nextAppointments": [
-    {
-      "id": "appointment-id",
-      "patientName": "Maria de Souza",
-      "professionalName": "Dr. João Silva",
-      "startAt": "2026-04-18T14:00:00.000Z",
-      "status": "CONFIRMED"
-    }
-  ]
+  "nextAppointments": []
 }
 ```
 
-## Padrão de erros
-Os erros devem seguir um padrão consistente e legível para o mobile.
+## Códigos de status mais comuns
 
-### Exemplos importantes
-- `401 Unauthorized` para token ausente ou inválido
-- `404 Not Found` para recurso inexistente
-- `409 Conflict` para conflito de horário
-- `400 Bad Request` para dados inválidos
-
-### Exemplo de erro
-```json
-{
-  "statusCode": 409,
-  "message": "The selected professional already has an appointment in this time slot.",
-  "error": "Conflict"
-}
-```
-
-## Observações de implementação
-- a documentação definitiva dos endpoints será refletida no Swagger/OpenAPI
-- este arquivo serve como contrato inicial entre backend e mobile
-- alterações relevantes nos payloads devem atualizar este documento
-
-## Nota de sincronização documental
-Sempre que houver mudança de rota, script ou variável de ambiente, atualizar este contrato e a documentação relacionada (`README.md` e `docs/architecture.md`) no mesmo conjunto de mudanças.
+- `200 OK` / `201 Created`
+- `400 Bad Request`
+- `401 Unauthorized`
+- `404 Not Found`
+- `409 Conflict`
+- `422 Unprocessable Entity`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,74 +1,44 @@
 # Architecture
 
 ## Visão geral
-O HospAgenda será estruturado como um monorepo contendo:
 
-- aplicação mobile em React Native
+O projeto está organizado em monorepo com três blocos principais:
+
+- app mobile em React Native (Expo Router)
 - API backend em NestJS
-- autenticação e banco de dados via Supabase em ambiente local
-- documentação técnica e funcional em uma pasta dedicada
+- autenticação + banco local via Supabase
 
-A proposta é manter um ambiente simples, reproduzível e adequado ao prazo do MVP, sem abrir mão de boas práticas de organização.
+A integração segue o fluxo **mobile → backend → banco/auth**, com o token de acesso emitido pelo Supabase e validado no backend.
 
 ## Objetivos arquiteturais
-A arquitetura foi definida para atender aos seguintes objetivos:
 
-- separar autenticação de regras de negócio
-- manter o backend como núcleo do domínio da aplicação
-- facilitar manutenção e evolução futura
-- manter baixo acoplamento entre camadas
-- favorecer testabilidade
-- preservar simplicidade compatível com o prazo
+- manter o backend como núcleo das regras de negócio
+- separar autenticação da lógica de domínio
+- preservar baixo acoplamento entre camadas
+- facilitar manutenção e evolução do MVP
+- manter setup local reproduzível e simples
 
-## Estrutura do sistema
-### Mobile
-Responsável por:
+## Estrutura real do monorepo
 
-- autenticação do usuário via Supabase Auth
-- navegação entre telas
-- formulários e fluxos de cadastro
-- consumo da API NestJS
-- exibição de dashboard e listagens
-
-### Backend
-Responsável por:
-
-- validação do token de autenticação
-- proteção de rotas
-- regras de negócio do domínio
-- validação dos dados recebidos
-- operações de leitura e escrita no banco
-- documentação da API
-
-### Supabase
-Responsável por:
-
-- autenticação local do usuário
-- persistência no banco PostgreSQL local
-
-## Decisão sobre autenticação
-A autenticação será feita pelo Supabase Auth. O aplicativo mobile realizará login e cadastro diretamente no Supabase, obtendo um token de acesso que será enviado ao backend nas requisições protegidas.
-
-O backend NestJS não emitirá tokens próprios neste MVP. Ele será responsável por validar o token recebido e identificar o usuário autenticado.
-
-### Motivação
-Essa decisão reduz a complexidade inicial do projeto, acelera a implementação do fluxo de acesso e permite concentrar esforço no domínio hospitalar, sem perder demonstração de integração e segurança básica.
-
-## Estrutura do monorepo
 ```text
 projeto-pdhc/
   backend/
   mobile/
   docs/
-  .github/
+  scripts/
 ```
 
-## Estrutura do backend
+## Estrutura real do backend
+
 ```text
 backend/
+  prisma/
   src/
     main.ts
     app.module.ts
+    health/
+    lib/
+      prisma/
     modules/
       auth/
       specialties/
@@ -76,17 +46,20 @@ backend/
       patients/
       appointments/
       dashboard/
-    common/
-      decorators/
-      dto/
-      enums/
-      guards/
-      filters/
-      interceptors/
-      utils/
+  test/
 ```
 
-## Estrutura do mobile
+### Responsabilidades do backend
+
+- validação do token Supabase (`SupabaseAuthGuard`)
+- exposição de API REST em `/api`
+- validação de entrada com DTOs + `ValidationPipe`
+- aplicação de regras de negócio (conflito de horário, status, datas)
+- persistência com Prisma/PostgreSQL
+- documentação automática com Swagger em `/docs`
+
+## Estrutura real do mobile
+
 ```text
 mobile/
   app/
@@ -96,121 +69,59 @@ mobile/
     (protected)/
   src/
     components/
-    services/
     hooks/
+    lib/
+    providers/
+    schemas/
+    services/
+    styles/
     types/
-    utils/
-    constants/
 ```
 
-## Portas e endpoints locais
-- backend NestJS: `http://127.0.0.1:3000`
-- prefixo global de rotas do backend: `/api`
+### Responsabilidades do mobile
+
+- autenticação do usuário no Supabase
+- gerenciamento de sessão em contexto (`AuthProvider`)
+- consumo da API do backend com `axios`
+- fluxo administrativo de cadastros e consultas
+- navegação protegida por rotas autenticadas
+
+## Contratos e portas locais
+
+- Backend: `http://127.0.0.1:3000`
+- Prefixo global de API: `/api`
+- Swagger: `http://127.0.0.1:3000/docs`
 - Supabase API local: `http://127.0.0.1:54321`
 - Postgres local (Supabase): `127.0.0.1:54322`
 
-Exemplo completo de endpoint protegido no ambiente local: `http://127.0.0.1:3000/api/auth/me`.
+## Modelo de autenticação
 
-## Módulos do backend
-### Auth
-Módulo responsável por:
-
-- validar o token recebido do Supabase
-- proteger rotas autenticadas
-- disponibilizar dados do usuário autenticado para os demais módulos
-
-### Specialties
-Módulo responsável por cadastro e listagem de especialidades.
-
-### Professionals
-Módulo responsável por cadastro, edição, visualização e listagem de profissionais.
-
-### Patients
-Módulo responsável por cadastro, edição, visualização e listagem de pacientes.
-
-### Appointments
-Módulo principal do domínio. Responsável por:
-
-- criação de consultas
-- validação de conflito de horário
-- confirmação
-- remarcação
-- cancelamento
-- conclusão
-- filtros de listagem
-
-### Dashboard
-Módulo responsável por consolidar dados do dia para exibição resumida no app.
-
-## Entidades principais
-### Specialty
-Representa uma especialidade médica cadastrada no sistema.
-
-### Professional
-Representa um profissional de saúde vinculado a uma única especialidade.
-
-### Patient
-Representa um paciente atendido pelo sistema.
-
-### Appointment
-Representa um agendamento de consulta, incluindo vínculo com paciente, profissional, especialidade, horário e status.
+1. app realiza sign in / sign up no Supabase
+2. Supabase devolve `access_token`
+3. app envia `Authorization: Bearer <token>` para a API
+4. backend valida o token e injeta o usuário autenticado na request
+5. módulos de domínio executam rotas protegidas
 
 ## Modelo de agendamento
-O sistema adotará uma abordagem simplificada para o tempo da consulta:
 
-- a consulta possui apenas `startAt`
-- a duração é implícita e fixa em 30 minutos
-- o `endAt` é derivado por cálculo quando necessário
+- cada consulta possui `startAt`
+- duração é implícita (30 minutos)
+- `specialtyId` do agendamento é derivado do profissional
+- status possíveis: `SCHEDULED`, `CONFIRMED`, `CANCELLED`, `COMPLETED`
 
-### Motivação
-Essa decisão reduz complexidade em:
+## Regras centrais de domínio
 
-- modelagem de dados
-- formulários
-- validação de conflito
-- testes
+- não criar/remarcar consulta no passado
+- não permitir conflito de horário por profissional
+- profissional deve ter especialidade válida
+- paciente/profissional devem existir para criar consulta
+- cancelamento preserva histórico (sem delete físico)
+- conclusão só para consultas ativas
 
-## Status de consulta
-Os status do agendamento serão:
+## Observação de sincronização documental
 
-- `SCHEDULED`
-- `CONFIRMED`
-- `CANCELLED`
-- `COMPLETED`
+Mudanças em rotas, payloads, variáveis de ambiente ou scripts devem atualizar em conjunto:
 
-## Fluxo de autenticação
-1. usuário realiza login ou cadastro no app
-2. Supabase Auth autentica o usuário
-3. o app recebe a sessão e o access token
-4. o token é enviado no header Authorization para a API
-5. o backend valida o token
-6. a rota protegida executa normalmente
-
-## Fluxo de criação de agendamento
-1. usuário autenticado seleciona paciente
-2. usuário seleciona profissional
-3. sistema considera a especialidade vinculada ao profissional
-4. usuário informa data/hora de início
-5. backend valida se a data é futura
-6. backend valida se não há conflito para o profissional
-7. backend cria o agendamento com status inicial
-
-## Princípios adotados
-- controllers finos
-- regras de negócio centralizadas em services
-- validação de entrada com DTOs
-- separação entre infraestrutura e domínio
-- documentação próxima da implementação
-- escopo controlado para preservar qualidade de entrega
-
-## Trade-offs assumidos
-- sem múltiplos perfis de usuário no MVP
-- sem delete físico
-- sem disponibilidade médica avançada
-- sem tempo real
-- sem múltiplas especialidades por profissional
-
-Esses trade-offs são intencionais e visam maximizar a qualidade do núcleo do sistema dentro do prazo disponível.
-
-## Nota de sincronização documental
-Qualquer alteração de rota, script ou variável de ambiente deve ser acompanhada de atualização imediata da documentação (`README.md`, `docs/architecture.md`, `docs/api-contract.md` e demais docs impactados).
+- `README.md`
+- `docs/api-contract.md`
+- `backend/README.md` e/ou `mobile/README.md`

--- a/docs/delivery-plan.md
+++ b/docs/delivery-plan.md
@@ -1,9 +1,11 @@
 # Delivery Plan
 
 ## Objetivo
+
 Organizar a execução do MVP do HospAgenda de forma pragmática, reduzindo riscos e garantindo foco nas entregas que mais contribuem para a qualidade final do projeto.
 
 ## Estratégia geral
+
 A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico prioriza:
 
 1. definição e organização do projeto
@@ -14,7 +16,9 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 6. testes e refinamento final
 
 ## Fase 1 — Estrutura inicial e documentação
+
 ### Objetivos
+
 - criar o repositório
 - definir estrutura do monorepo
 - criar os documentos base
@@ -23,6 +27,7 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - preparar GitHub Actions inicial
 
 ### Entregas esperadas
+
 - repositório criado
 - pasta `docs/` preenchida com base inicial
 - Project configurado
@@ -30,7 +35,9 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - workflows básicos de CI criados
 
 ## Fase 2 — Setup técnico e autenticação
+
 ### Objetivos
+
 - subir Supabase local
 - configurar backend NestJS
 - configurar app React Native
@@ -39,24 +46,30 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - expor rota protegida mínima
 
 ### Entregas esperadas
+
 - ambiente local funcional
 - fluxo de login/cadastro funcionando
 - rota `/auth/me` funcionando com proteção
 
 ## Fase 3 — Cadastros base no backend
+
 ### Objetivos
+
 - implementar especialidades
 - implementar profissionais
 - implementar pacientes
 - documentar endpoints no Swagger
 
 ### Entregas esperadas
+
 - endpoints funcionando
 - validações básicas implementadas
 - documentação inicial da API disponível
 
 ## Fase 4 — Agendamentos no backend
+
 ### Objetivos
+
 - implementar criação de consulta
 - implementar listagem com filtros
 - implementar confirmação
@@ -67,24 +80,30 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - validar data passada
 
 ### Entregas esperadas
+
 - núcleo do domínio funcionando
 - regras principais implementadas
 - endpoints documentados
 
 ## Fase 5 — Dashboard e integração mobile
+
 ### Objetivos
+
 - implementar endpoint de dashboard do dia
 - criar telas principais do app
 - conectar formulários e listagens com a API
 - permitir execução dos fluxos administrativos principais
 
 ### Entregas esperadas
+
 - dashboard funcional
 - app autenticado consumindo a API
 - criação e gestão de agendamentos via interface mobile
 
 ## Fase 6 — Testes e refinamento
+
 ### Objetivos
+
 - criar testes unitários do domínio de agendamento
 - criar testes de integração prioritários
 - revisar documentação
@@ -92,12 +111,15 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - capturar evidências visuais do projeto
 
 ### Entregas esperadas
+
 - suíte mínima de testes concluída
 - documentação revisada
 - projeto preparado para submissão
 
 ## Sugestão de distribuição por dias
+
 ### Dia 1
+
 - repositório
 - docs base
 - GitHub Projects
@@ -105,34 +127,41 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - Supabase local
 
 ### Dia 2
+
 - autenticação fim a fim
 - especialidades
 - profissionais
 - pacientes
 
 ### Dia 3
+
 - agendamentos
 - conflito de horário
 - regras de status
 
 ### Dia 4
+
 - dashboard
 - integração mobile base
 - listagens principais
 
 ### Dia 5
+
 - formulários e ações de agendamento
 - testes de backend
 - ajustes de UX
 
 ### Dia 6
+
 - CI
 - revisão final
 - README final
 - screenshots e preparação de entrega
 
 ## Critérios de prioridade
+
 ### Prioridade máxima
+
 - autenticação
 - criação de consulta
 - conflito de horário
@@ -141,15 +170,18 @@ A entrega será conduzida em fases curtas e orientadas a risco. O fluxo técnico
 - testes centrais
 
 ### Prioridade média
+
 - dashboard
 - filtros completos
 - refinamento visual
 
 ### Prioridade baixa
+
 - polimento adicional de interface
 - melhorias não essenciais
 
 ## Critérios de corte
+
 Se o prazo apertar, reduzir nesta ordem:
 
 1. refinamentos visuais mais avançados
@@ -166,6 +198,7 @@ Não reduzir:
 - testes principais
 
 ## Resultado esperado ao final
+
 Ao final da execução, o projeto deve apresentar:
 
 - arquitetura coerente
@@ -177,15 +210,16 @@ Ao final da execução, o projeto deve apresentar:
 - organização profissional do processo de desenvolvimento
 
 ## Demo em 10 minutos
+
 Esta seção descreve um roteiro direto para demonstração funcional do MVP.
 
 ### 1) Comandos exatos para subir o ambiente
+
 No diretório raiz do projeto:
 
 ```bash
+cp .env.example .env
 npm run setup
-cp backend/.env.example backend/.env
-cp mobile/.env.example mobile/.env
 npm run supabase:start
 npm run dev:backend
 ```
@@ -197,21 +231,25 @@ npm run dev:mobile
 ```
 
 Referências úteis durante a demo:
+
 - Swagger: `http://localhost:3000/docs`
 - API base: `http://localhost:3000/api`
 
 ### 2) Criação de usuário no app (sign-up) e login
+
 1. Abrir o app e acessar a tela de cadastro (`Sign up`).
 2. Informar e-mail válido e senha.
 3. Concluir cadastro e, em seguida, acessar a tela de login (`Sign in`).
 4. Autenticar com o mesmo e-mail/senha.
 
 **Resultado esperado**
+
 - Login concluído com sucesso.
 - Usuário redirecionado para área protegida (dashboard/listas).
 - Requisições autenticadas passam a funcionar sem erro `401`.
 
 ### 3) Sequência mínima de uso (fluxo obrigatório)
+
 Executar nesta ordem para evitar dependências quebradas:
 
 1. **Cadastrar especialidade**
@@ -239,6 +277,7 @@ Executar nesta ordem para evitar dependências quebradas:
    - **Resultado esperado:** status final da consulta refletido corretamente no detalhe/listagem.
 
 ### 4) Verificação de API no Swagger para cada fluxo
+
 No Swagger (`/docs`), clicar em **Authorize** e informar:
 `Bearer <access_token>`.
 
@@ -268,6 +307,7 @@ Validar os endpoints abaixo em paralelo à navegação no app:
    - `PATCH /api/appointments/{id}/complete`
 
 ### 5) Resultado esperado por etapa (checklist para avaliação)
+
 - **Ambiente iniciado:** backend responde e Swagger abre em `http://localhost:3000/docs`.
 - **Usuário autenticado:** login no app funcionando e rotas protegidas acessíveis.
 - **Especialidade criada:** retorno `201` no POST e item visível no GET.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,85 +1,56 @@
-# Mobile App
+# Mobile App (Expo)
 
-Aplicativo React Native (Expo Router) do projeto PDHC.
+Aplicativo React Native do projeto PDHC, com rotas públicas de autenticação e rotas protegidas para operação administrativa.
 
 ## Pré-requisitos
 
-- Node.js e npm instalados.
-- Expo CLI via `npx` (não é necessário instalar globalmente).
-- Emulador Android é opcional (também é possível rodar em dispositivo físico com Expo Go).
+- Node.js + npm
+- Expo (via `npx`)
+- Android Emulator ou dispositivo físico (Expo Go)
 
-## Configuração de ambiente (`.env`)
+## Configuração de ambiente
 
-1. Copie o arquivo de exemplo:
+O app consome variáveis `EXPO_PUBLIC_*` geradas automaticamente em `mobile/.env` a partir do `.env` da raiz.
+
+1. Na raiz do projeto, configure:
 
 ```bash
-cp mobile/.env.example mobile/.env
+cp .env.example .env
 ```
 
-2. Preencha no `mobile/.env` as variáveis obrigatórias do projeto (ex.: URL da API e credenciais públicas usadas pelo app).
+2. Preencha ao menos:
 
-## Configuração de rede (obrigatório)
+- `EXPO_PUBLIC_API_URL`
+- `EXPO_PUBLIC_SUPABASE_URL`
+- `EXPO_PUBLIC_SUPABASE_ANON_KEY`
 
-Defina `EXPO_PUBLIC_API_URL` corretamente de acordo com onde o app vai rodar:
+3. Gere o `mobile/.env`:
 
-- **Emulador Android**:
-
-```env
-EXPO_PUBLIC_API_URL=http://10.0.2.2:3000
+```bash
+npm run sync:mobile-env
 ```
 
-- **Dispositivo físico (mesma rede LAN da sua máquina)**:
-  - Use o IP local da sua máquina, por exemplo:
+> `npm run dev:mobile` e `npm run dev` já executam esse sync automaticamente.
 
-```env
-EXPO_PUBLIC_API_URL=http://192.168.0.10:3000
-```
+## Configuração de rede (`EXPO_PUBLIC_API_URL`)
 
-> `mobile/src/lib/api.ts` adiciona o sufixo `/api` automaticamente.  
-> Exemplo: se `EXPO_PUBLIC_API_URL=http://10.0.2.2:3000`, as requisições irão para `http://10.0.2.2:3000/api`.
+- Android Emulator: `http://10.0.2.2:3000`
+- Dispositivo físico (mesma LAN): `http://192.168.x.x:3000`
 
-## Fluxos de execução
+O app adiciona `/api` automaticamente no cliente HTTP.
 
-### 1) Rodar o ambiente completo pela raiz
+## Como executar
 
 Na raiz do monorepo:
 
-```bash
-npm run dev
-```
+- `npm run dev` → fluxo completo recomendado (supabase + backend + mobile emulador)
+- `npm run dev:mobile` → apenas Expo start
+- `npm run dev:mobile:emulator` → Expo localhost (bom para emulador)
+- `npm run dev:mobile:android` → tenta abrir Android automaticamente
 
-Esse fluxo sobe:
+## Checklist rápido
 
-- Supabase local
-- backend NestJS
-- mobile Expo na porta 8082
-
-### 2) Rodar somente o mobile
-
-Na raiz do monorepo:
-
-```bash
-npm --prefix mobile run emulator
-```
-
-(Equivalente a entrar em `mobile/` e executar `npm run emulator`.)
-
-## Checklist de validação
-
-- [ ] O app inicia sem erro no emulador/dispositivo.
-- [ ] O login/autenticação funciona com as credenciais esperadas.
-- [ ] A listagem de dados do backend é carregada com sucesso no app.
-
-## Erros comuns
-
-- **Timeout da API**
-  - Verifique se backend está rodando e acessível na porta `3000`.
-  - Confirme se `EXPO_PUBLIC_API_URL` está apontando para host correto do contexto (emulador vs dispositivo físico).
-
-- **Host incorreto**
-  - Emulador Android não acessa `localhost` da mesma forma que sua máquina host.
-  - Use `10.0.2.2` no emulador ou IP LAN em dispositivo físico.
-
-- **Supabase URL incorreta**
-  - Revise variáveis do `.env` copiadas de `mobile/.env.example`.
-  - Garanta que a URL/keys utilizadas correspondem ao ambiente em execução.
+- app inicia sem erro
+- login/cadastro funcionam
+- listagens de especialidades/profissionais/pacientes carregam
+- criação/edição de consulta funciona com backend autenticado


### PR DESCRIPTION
### Motivation
- Reduzir divergências entre a documentação e a implementação atual do monorepo, tornando o onboarding e a demonstração do MVP mais diretos. 
- Centralizar a configuração de ambiente para evitar ambiguidade sobre onde definir variáveis (`.env` raiz vs arquivos por módulo). 
- Garantir que o roteiro de demo, contratos de API e guias de execução reflitam os scripts e endpoints verdadeiros do repositório.

### Description
- Reescreve o `README.md` da raiz para refletir o status atual do MVP, setup rápido real e lista de endpoints e scripts válidos, incluindo a fonte única de variáveis no `.env` da raiz. 
- Atualiza `docs/api-contract.md`, `docs/architecture.md` e `docs/delivery-plan.md` para alinhar contratos, estrutura real do monorepo e a sequência correta de bootstrap (ex.: usar `cp .env.example .env` + `npm run setup` + `npm run supabase:start`). 
- Padroniza e simplifica os READMEs de `backend/` e `mobile/` para indicar execução a partir da raiz e remover instruções desatualizadas de `.env` por módulo. 
- Aplica formatação consistente com Prettier nos arquivos alterados e ajusta exemplos e mensagens (Swagger/erros/exemplos de payloads) para refletir a implementação atual.

### Testing
- Executei `npx prettier --write` sobre os arquivos modificados para corrigir formatação e em seguida `npx prettier --check` para validar a consistência, ambos concluídos com sucesso. 
- Não foram executados testes unitários ou e2e nesta revisão; a alteração é estritamente documental e de formatação. 
- Todos os arquivos documentais alterados foram commitados após validação do Prettier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9e8f5bcc83299003bac3e7dafcae)