### PR TITLE
Use Brasília timezone when computing dashboard 'today' date

### DIFF
--- a/mobile/src/services/dashboard/get-dashboard-today.ts
+++ b/mobile/src/services/dashboard/get-dashboard-today.ts
@@ -1,12 +1,23 @@
 import { api } from '@/lib/api';
 import { DashboardTodayResponse } from '@/types/dashboard';
 
+// IANA timezone used for horário de Brasília (BRT/BRST).
+// "America/Brasilia" is not supported in modern Intl implementations.
+const BRASILIA_TIME_ZONE = 'America/Sao_Paulo';
+
+function getTodayInBrasiliaTimezone(): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: BRASILIA_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+
+  return formatter.format(new Date());
+}
+
 export async function getDashboardToday(): Promise<DashboardTodayResponse> {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  const dateString = `${year}-${month}-${day}`;
+  const dateString = getTodayInBrasiliaTimezone();
 
   const response = await api.get<DashboardTodayResponse>(
     `/dashboard/today?date=${dateString}`,


### PR DESCRIPTION
### Motivation
- Ensure the dashboard's `today` date is computed in Brasília time so server queries use the expected local date. 
- Avoid using the non-standard `America/Brasilia` identifier which is not supported by modern `Intl` implementations.

### Description
- Add `BRASILIA_TIME_ZONE` constant set to `"America/Sao_Paulo"` for the Brasília/IANA timezone mapping. 
- Implement `getTodayInBrasiliaTimezone()` using `Intl.DateTimeFormat('en-CA', { timeZone, year, month, day })` to produce a `YYYY-MM-DD` date string. 
- Replace the previous local `Date` manual formatting logic with a call to `getTodayInBrasiliaTimezone()` when building the `/dashboard/today?date=` request.

### Testing
- Ran a TypeScript type check via `tsc --noEmit` which completed successfully. 
- Ran the test suite via `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0a3256f083299a1e2f3df3191f42)