### PR TITLE
Add patient delete endpoint with appointment guard and mobile delete UI + e2e tests

### DIFF
--- a/backend/src/modules/patients/patients.controller.ts
+++ b/backend/src/modules/patients/patients.controller.ts
@@ -1,7 +1,9 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
+  HttpCode,
   Param,
   Patch,
   Post,
@@ -11,10 +13,12 @@ import {
   ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
+  ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiUnprocessableEntityResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { SupabaseAuthGuard } from '../auth/guards/supabase-auth.guard';
@@ -84,5 +88,18 @@ export class PatientsController {
     @Body() updatePatientDto: UpdatePatientDto,
   ): Promise<PatientResponseDto> {
     return this.patientsService.update(id, updatePatientDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Delete a patient by id' })
+  @ApiNoContentResponse({ description: 'Patient deleted successfully' })
+  @ApiNotFoundResponse({ description: 'Patient not found' })
+  @ApiUnprocessableEntityResponse({
+    description: 'Patient has appointments with status scheduled or confirmed',
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid bearer token' })
+  async remove(@Param('id') id: string): Promise<void> {
+    await this.patientsService.remove(id);
   }
 }

--- a/backend/src/modules/patients/patients.service.ts
+++ b/backend/src/modules/patients/patients.service.ts
@@ -2,7 +2,9 @@ import {
   ConflictException,
   Injectable,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
+import { AppointmentStatus } from '@prisma/client';
 import { PrismaService } from '../../lib/prisma/prisma.service';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
@@ -59,6 +61,30 @@ export class PatientsService {
         }),
         ...(dto.phone !== undefined && { phone: dto.phone }),
       },
+    });
+  }
+
+  async remove(id: string) {
+    await this.findOne(id);
+
+    const activeAppointment = await this.prisma.appointment.findFirst({
+      where: {
+        patientId: id,
+        status: {
+          in: [AppointmentStatus.SCHEDULED, AppointmentStatus.CONFIRMED],
+        },
+      },
+      select: { id: true },
+    });
+
+    if (activeAppointment) {
+      throw new UnprocessableEntityException(
+        'Não é possível excluir o paciente pois ele possui consulta agendada ou confirmada.',
+      );
+    }
+
+    await this.prisma.patient.delete({
+      where: { id },
     });
   }
 

--- a/backend/test/patients.e2e-spec.ts
+++ b/backend/test/patients.e2e-spec.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../src/lib/prisma/prisma.service';
 import { SupabaseAuthService } from '../src/modules/auth/services/supabase-auth.service';
 import { setupE2eApp } from './utils/e2e-setup';
 import { randomUUID } from 'crypto';
+import { AppointmentStatus } from '@prisma/client';
 
 describe('PatientsController (e2e)', () => {
   let app: INestApplication;
@@ -197,6 +198,74 @@ describe('PatientsController (e2e)', () => {
 
       // Cleanup
       await prisma.patient.delete({ where: { id: patient.id } });
+    });
+  });
+
+  describe('DELETE /api/patients/:id', () => {
+    it('deletes patient when there is no scheduled or confirmed appointment', async () => {
+      const patient = await prisma.patient.create({
+        data: {
+          fullName: 'Delete Me',
+          cpf: Math.random().toString().slice(2, 13),
+          birthDate: new Date('1992-06-10'),
+          phone: '11911111111',
+        },
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/api/patients/${patient.id}`)
+        .set('Authorization', validToken)
+        .expect(204);
+
+      const deletedPatient = await prisma.patient.findUnique({
+        where: { id: patient.id },
+      });
+      expect(deletedPatient).toBeNull();
+    });
+
+    it('returns 422 when patient has appointment with status scheduled', async () => {
+      const specialty = await prisma.specialty.create({
+        data: { name: `E2E Del ${randomUUID().slice(0, 8)}` },
+      });
+      const professional = await prisma.professional.create({
+        data: {
+          fullName: 'E2E Del Professional',
+          specialtyId: specialty.id,
+        },
+      });
+      const patient = await prisma.patient.create({
+        data: {
+          fullName: 'Locked Patient',
+          cpf: Math.random().toString().slice(2, 13),
+          birthDate: new Date('1991-04-01'),
+          phone: '11922222222',
+        },
+      });
+      const appointment = await prisma.appointment.create({
+        data: {
+          patientId: patient.id,
+          professionalId: professional.id,
+          specialtyId: specialty.id,
+          startAt: new Date(Date.now() + 2 * 60 * 60 * 1000),
+          status: AppointmentStatus.SCHEDULED,
+        },
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/api/patients/${patient.id}`)
+        .set('Authorization', validToken)
+        .expect(422)
+        .expect((res) => {
+          const body = res.body as { message: string };
+          expect(body.message).toBe(
+            'Não é possível excluir o paciente pois ele possui consulta agendada ou confirmada.',
+          );
+        });
+
+      await prisma.appointment.delete({ where: { id: appointment.id } });
+      await prisma.patient.delete({ where: { id: patient.id } });
+      await prisma.professional.delete({ where: { id: professional.id } });
+      await prisma.specialty.delete({ where: { id: specialty.id } });
     });
   });
 });

--- a/mobile/app/(protected)/dashboard.tsx
+++ b/mobile/app/(protected)/dashboard.tsx
@@ -18,6 +18,7 @@ import { getDashboardToday } from '@/services/dashboard/get-dashboard-today';
 import type { DashboardTodayResponse } from '@/types/dashboard';
 import { AppointmentListItem } from '@/components/appointments/AppointmentListItem';
 import { AppointmentsEmptyState } from '@/components/appointments/AppointmentsEmptyState';
+import { ConfirmActionModal } from '@/components/ui/ConfirmActionModal';
 
 export default function DashboardScreen() {
   const { user, signOut } = useAuth();
@@ -25,6 +26,8 @@ export default function DashboardScreen() {
   const [data, setData] = useState<DashboardTodayResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [isLogoutModalVisible, setIsLogoutModalVisible] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   const loadDashboard = useCallback(async () => {
     try {
@@ -47,6 +50,7 @@ export default function DashboardScreen() {
 
   async function handleSignOut() {
     try {
+      setIsSigningOut(true);
       await signOut();
     } catch {
       Toast.show({
@@ -54,6 +58,9 @@ export default function DashboardScreen() {
         text1: 'Erro ao sair',
         text2: 'Não foi possível sair da conta agora.',
       });
+    } finally {
+      setIsSigningOut(false);
+      setIsLogoutModalVisible(false);
     }
   }
 
@@ -108,7 +115,7 @@ export default function DashboardScreen() {
           </View>
           <TouchableOpacity
             style={styles.logoutButton}
-            onPress={handleSignOut}
+            onPress={() => setIsLogoutModalVisible(true)}
             activeOpacity={0.8}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
@@ -229,6 +236,24 @@ export default function DashboardScreen() {
           </View>
         </View>
       </ScrollView>
+
+      <ConfirmActionModal
+        visible={isLogoutModalVisible}
+        title="Sair da conta"
+        message="Tem certeza de que deseja sair da sua conta?"
+        cancelLabel="Cancelar"
+        confirmLabel="Sair"
+        isLoading={isSigningOut}
+        onCancel={() => {
+          if (isSigningOut) {
+            return;
+          }
+          setIsLogoutModalVisible(false);
+        }}
+        onConfirm={() => {
+          void handleSignOut();
+        }}
+      />
 
       <TouchableOpacity
         style={styles.fab}

--- a/mobile/app/(protected)/patients/index.tsx
+++ b/mobile/app/(protected)/patients/index.tsx
@@ -24,6 +24,7 @@ import { PatientsInlineError } from '@/components/patients/PatientsInlineError';
 import { PatientsLoadErrorState } from '@/components/patients/PatientsLoadErrorState';
 import { PatientsLoadingState } from '@/components/patients/PatientsLoadingState';
 import { AppButton } from '@/components/ui/AppButton';
+import { ConfirmActionModal } from '@/components/ui/ConfirmActionModal';
 import { FAB } from '@/components/ui/FAB';
 import { ProfessionalsHeader } from '@/components/professionals/ProfessionalsHeader';
 import {
@@ -32,6 +33,7 @@ import {
   type PatientFormRawValues,
 } from '@/schemas/patients/patient-form-schema';
 import { createPatient } from '@/services/patients/create-patient';
+import { deletePatient } from '@/services/patients/delete-patient';
 import { listPatients } from '@/services/patients/list-patients';
 import { colors } from '@/styles/colors';
 import type { Patient } from '@/types/patient';
@@ -41,6 +43,8 @@ export default function PatientsScreen() {
   const [isLoadingList, setIsLoadingList] = useState(true);
   const [isRefreshingList, setIsRefreshingList] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [patientToDelete, setPatientToDelete] = useState<Patient | null>(null);
+  const [isDeletingPatient, setIsDeletingPatient] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
 
@@ -85,6 +89,51 @@ export default function PatientsScreen() {
       setIsSubmitting(false);
     }
   }
+
+  const handleDeletePatient = useCallback((patient: Patient) => {
+    setPatientToDelete(patient);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    if (isDeletingPatient) {
+      return;
+    }
+
+    setPatientToDelete(null);
+  }, [isDeletingPatient]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!patientToDelete) {
+      return;
+    }
+
+    try {
+      setIsDeletingPatient(true);
+      await deletePatient(patientToDelete.id);
+
+      Toast.show({
+        type: 'success',
+        text1: 'Paciente excluído',
+        text2: 'O paciente foi removido com sucesso.',
+      });
+
+      setPatients((current) =>
+        current.filter((item) => item.id !== patientToDelete.id),
+      );
+      setPatientToDelete(null);
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: 'Não foi possível excluir',
+        text2: getErrorMessage(
+          error,
+          'Verifique se não há consulta agendada ou confirmada.',
+        ),
+      });
+    } finally {
+      setIsDeletingPatient(false);
+    }
+  }, [patientToDelete]);
 
   const hasPatients = patients.length > 0;
 
@@ -186,6 +235,20 @@ export default function PatientsScreen() {
             </View>
           </Modal>
 
+          <ConfirmActionModal
+            visible={Boolean(patientToDelete)}
+            title="Excluir paciente"
+            message="Tem certeza que deseja excluir"
+            highlightText={patientToDelete?.fullName}
+            cancelLabel="Cancelar"
+            confirmLabel="Excluir"
+            isLoading={isDeletingPatient}
+            onCancel={handleCancelDelete}
+            onConfirm={() => {
+              void handleConfirmDelete();
+            }}
+          />
+
           <View style={styles.listSection}>
             <View style={styles.listHeader}>
               <Text style={styles.listTitle}>Lista de pacientes</Text>
@@ -229,6 +292,7 @@ export default function PatientsScreen() {
                     onEditPress={() =>
                       router.push(`./patients/${item.id}/edit`)
                     }
+                    onDeletePress={() => handleDeletePatient(item)}
                   />
                 )}
                 refreshing={isRefreshingList}

--- a/mobile/src/components/patients/PatientListItem.tsx
+++ b/mobile/src/components/patients/PatientListItem.tsx
@@ -7,11 +7,13 @@ import { colors } from '@/styles/colors';
 type PatientListItemProps = {
   patient: Patient;
   onEditPress: () => void;
+  onDeletePress: () => void;
 };
 
 export function PatientListItem({
   patient,
   onEditPress,
+  onDeletePress,
 }: PatientListItemProps) {
   return (
     <View style={styles.container}>
@@ -20,14 +22,25 @@ export function PatientListItem({
         <Text style={styles.detail}>CPF: {patient.cpf}</Text>
       </View>
 
-      <TouchableOpacity
-        activeOpacity={0.7}
-        onPress={onEditPress}
-        style={styles.editButton}
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-      >
-        <Ionicons name="pencil-outline" size={18} color={colors.primary} />
-      </TouchableOpacity>
+      <View style={styles.actions}>
+        <TouchableOpacity
+          activeOpacity={0.7}
+          onPress={onEditPress}
+          style={styles.editButton}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons name="pencil-outline" size={18} color={colors.primary} />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          activeOpacity={0.7}
+          onPress={onDeletePress}
+          style={styles.deleteButton}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons name="trash-outline" size={18} color={colors.danger} />
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }
@@ -58,6 +71,20 @@ const styles = StyleSheet.create({
     fontSize: 13,
   },
   editButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.inputBackground,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  deleteButton: {
     width: 36,
     height: 36,
     borderRadius: 10,

--- a/mobile/src/components/ui/ConfirmActionModal.tsx
+++ b/mobile/src/components/ui/ConfirmActionModal.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { colors } from '@/styles/colors';
+
+type ConfirmActionModalProps = {
+  visible: boolean;
+  title: string;
+  message: string;
+  highlightText?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  isLoading?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function ConfirmActionModal({
+  visible,
+  title,
+  message,
+  highlightText,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  isLoading = false,
+  onCancel,
+  onConfirm,
+}: ConfirmActionModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.card}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.message}>
+            {message}
+            {highlightText ? (
+              <>
+                {' '}
+                <Text style={styles.highlight}>{highlightText}</Text>?
+              </>
+            ) : null}
+          </Text>
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={styles.cancelButton}
+              activeOpacity={0.8}
+              disabled={isLoading}
+              onPress={onCancel}
+            >
+              <Text style={styles.cancelText}>{cancelLabel}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[
+                styles.confirmButton,
+                isLoading ? styles.confirmButtonDisabled : null,
+              ]}
+              activeOpacity={0.8}
+              disabled={isLoading}
+              onPress={onConfirm}
+            >
+              <Text style={styles.confirmText}>
+                {isLoading ? 'Processando...' : confirmLabel}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 18,
+    gap: 14,
+  },
+  title: {
+    color: colors.text,
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  message: {
+    color: colors.textMuted,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  highlight: {
+    color: colors.text,
+    fontWeight: '700',
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+  },
+  cancelButton: {
+    minWidth: 100,
+    height: 42,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.inputBackground,
+  },
+  cancelText: {
+    color: colors.text,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  confirmButton: {
+    minWidth: 100,
+    height: 42,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.danger,
+  },
+  confirmButtonDisabled: {
+    opacity: 0.7,
+  },
+  confirmText: {
+    color: colors.surface,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});

--- a/mobile/src/services/patients/delete-patient.ts
+++ b/mobile/src/services/patients/delete-patient.ts
@@ -1,0 +1,5 @@
+import { api } from '@/lib/api';
+
+export async function deletePatient(id: string) {
+  await api.delete(`/patients/${id}`);
+}


### PR DESCRIPTION
### Motivation
- Allow deleting a patient from the API while preventing deletion when the patient has scheduled or confirmed appointments. 
- Expose safe deletion from the mobile app with a confirmation modal to avoid accidental removals. 
- Cover the new behavior with end-to-end tests to avoid regressions.

### Description
- Backend: added `DELETE /patients/:id` in `PatientsController` with `204` response and swagger docs, and implemented `PatientsService.remove` which checks for appointments with `AppointmentStatus.SCHEDULED` or `AppointmentStatus.CONFIRMED` and throws `UnprocessableEntityException` if any are found, otherwise deletes the patient. 
- Tests: extended `backend/test/patients.e2e-spec.ts` to include deletion scenarios, importing `AppointmentStatus` and asserting both successful deletion and a `422` when a scheduled appointment exists. 
- Mobile: added a reusable `ConfirmActionModal` component, a `deletePatient` service (`mobile/src/services/patients/delete-patient.ts`), a delete button in `PatientListItem`, and deletion flow in the patients screen including confirmation, loading state, toast notifications and optimistic UI update; also added a logout confirmation using the same modal in the dashboard.

### Testing
- Ran the patients e2e suite (`backend/test/patients.e2e-spec.ts`) which includes the new `DELETE /api/patients/:id` scenarios, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec508a06588329845226cb954225bd)